### PR TITLE
Update theme: Private Mode Highlighting

### DIFF
--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
@@ -1,20 +1,37 @@
+/**
+ * This Zen theme adds additional styling to the private browsing mode window such as a gradient on the toolbar,
+ * a border around the browser page, and an icon in the URL bar. These are configurable in Zen's Look and Feel settings.
+ *
+ * The --pbmh prefix stands for Private Browsing Mode Highlighting.
+ */
+
+:root {
+  --pbmh-private-browsing-mode-color: #25003E;
+  --pbmh-private-browsing-mode-border: hsl(from var(--pbmh-private-browsing-mode-color) h s calc(l + 20));
+}
+
+[devtoolstheme=light] {
+  --pbmh-private-browsing-mode-color: #C080EB;
+  --pbmh-private-browsing-mode-border: hsl(from var(--pbmh-private-browsing-mode-color) h s calc(l - 20));
+}
+
 @media not (-moz-bool-pref: "uc.private-browsing-top-bar.no-bg") {
   [privatebrowsingmode] #nav-bar {
-    background-image: linear-gradient(to bottom, #25003EFF, #25003E00 98%) !important;
-  }
-
-  [privatebrowsingmode] [devtoolstheme=light] #nav-bar {
-    background-image: linear-gradient(to bottom, #C080EBFF, #ffffff00 98%) !important;
+    background-image: linear-gradient(to bottom, var(--pbmh-private-browsing-mode-color), rgb(from var(--pbmh-private-browsing-mode-color) r g b / 0%) 98%) !important;
   }
 
   @media (-moz-bool-pref: "uc.private-browsing-top-bar.solid-bg") {
     [privatebrowsingmode] #nav-bar {
       background-image: none !important;
-      background-color: #25003E !important;
+      background-color: var(--pbmh-private-browsing-mode-color) !important;
     }
+  }
+}
 
-    [privatebrowsingmode] [devtoolstheme=light] #nav-bar {
-      background-color: #C080EB !important;
+@media not (-moz-bool-pref: "uc.private-browsing-top-bar.no-border") {
+  :root[privatebrowsingmode]:not([inDOMFullscreen="true"]):not([chromehidden~="location"]):not([chromehidden~="toolbar"]) {
+    & #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+      box-shadow: 0 0 0 2px var(--pbmh-private-browsing-mode-border) !important;
     }
   }
 }
@@ -49,7 +66,7 @@
    *If the spring has been remvoed (e.g., the browser width is too small), 
    *then add a margin to the URL bar to prevent it from overlapping the icon
    */
-  [privatebrowsingmode] #stop-reload-button + #urlbar-container {
+  [privatebrowsingmode] #stop-reload-button+#urlbar-container {
     margin-inline-start: 40px !important;
   }
 }

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
@@ -4,7 +4,7 @@
   }
 
   [privatebrowsingmode] [devtoolstheme=light] #nav-bar {
-    background-image: linear-gradient(to bottom, #C080EB, #ffffff00 98%) !important;
+    background-image: linear-gradient(to bottom, #C080EBFF, #ffffff00 98%) !important;
   }
 
   @media (-moz-bool-pref: "uc.private-browsing-top-bar.solid-bg") {
@@ -38,14 +38,18 @@
     pointer-events: none;
   }
 
-  /* Prevents the spring from collapsing too far and causing the URL bar to overlap the icon */
+  /*
+   * Prevents the spring from collapsing too far and causing the URL bar to overlap the icon 
+   */
   [privatebrowsingmode] toolbarspring:has(+ #urlbar-container) {
     min-width: 40px !important;
   }
 
-  @media (max-width: 704px) {
-    [privatebrowsingmode] #urlbar-container {
-      margin-inline-start: 40px !important;
-    }
+  /* 
+   *If the spring has been remvoed (e.g., the browser width is too small), 
+   *then add a margin to the URL bar to prevent it from overlapping the icon
+   */
+  [privatebrowsingmode] #stop-reload-button + #urlbar-container {
+    margin-inline-start: 40px !important;
   }
 }

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
@@ -7,7 +7,7 @@
     background-image: linear-gradient(to bottom, #C080EB, #ffffff00 98%) !important;
   }
 
-@media (-moz-bool-pref: "uc.private-browsing-top-bar.solid-bg") {
+  @media (-moz-bool-pref: "uc.private-browsing-top-bar.solid-bg") {
     [privatebrowsingmode] #nav-bar {
       background-image: none !important;
       background-color: #25003E !important;
@@ -24,7 +24,7 @@
     position: relative;
   }
 
-[privatebrowsingmode] #stop-reload-button::after {
+  [privatebrowsingmode] #stop-reload-button::after {
     content: "";
     position: absolute;
     left: 100%;
@@ -34,5 +34,18 @@
     background-image: url("chrome://global/skin/icons/indicator-private-browsing.svg");
     background-repeat: no-repeat;
     background-position: center center;
+    background-size: 70%;
+    pointer-events: none;
+  }
+
+  /* Prevents the spring from collapsing too far and causing the URL bar to overlap the icon */
+  [privatebrowsingmode] toolbarspring:has(+ #urlbar-container) {
+    min-width: 40px !important;
+  }
+
+  @media (max-width: 704px) {
+    [privatebrowsingmode] #urlbar-container {
+      margin-inline-start: 40px !important;
+    }
   }
 }

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
@@ -1,13 +1,20 @@
-
 @media not (-moz-bool-pref: "uc.private-browsing-top-bar.no-bg") {
   [privatebrowsingmode] #nav-bar {
-    background-image: linear-gradient(to bottom, #25003EFF, #25003E44) !important;
+    background-image: linear-gradient(to bottom, #25003EFF, #25003E00 98%) !important;
+  }
+
+  [privatebrowsingmode] [devtoolstheme=light] #nav-bar {
+    background-image: linear-gradient(to bottom, #C080EB, #ffffff00 98%) !important;
   }
 
 @media (-moz-bool-pref: "uc.private-browsing-top-bar.solid-bg") {
     [privatebrowsingmode] #nav-bar {
       background-image: none !important;
       background-color: #25003E !important;
+    }
+
+    [privatebrowsingmode] [devtoolstheme=light] #nav-bar {
+      background-color: #C080EB !important;
     }
   }
 }

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/preferences.json
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/preferences.json
@@ -1,5 +1,6 @@
 {
-    "uc.private-browsing-top-bar.solid-bg": "Replaces the purple gradient on the toolbar with a solid purple color",
-    "uc.private-browsing-top-bar.no-bg": "Removes the background color on the toolbar entirely",
+    "uc.private-browsing-top-bar.solid-bg": "Replaces the purple gradient on the toolbar with a solid purple color", 
+    "uc.private-browsing-top-bar.no-bg": "Removes the background color on the toolbar entirely", 
+    "uc.private-browsing-top-bar.no-border": "Removes the purple border that surrounds the page",
     "uc.private-browsing-top-bar.hide-icon": "Hides the private browsing icon"
 }

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/readme.md
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/readme.md
@@ -1,5 +1,4 @@
-
-# Private Browsing Toolbar Highlighting
+# Private Browsing Mode Highlighting
 
 Any Zen window in private browsing mode isn't obviously indicated by default. This theme fixes that.
 
@@ -8,12 +7,14 @@ Any Zen window in private browsing mode isn't obviously indicated by default. Th
 By default, this theme:
 
 * Highlights the toolbar of a private browsing window with a purple gradient.
+* Adds a purple border surrounding the page.
 * Adds a private browsing icon to the right of the refresh button.
 
 It also comes with three settings:
 
 * Replace the gradient with a solid purple color.
 * Remove the background color entirely.
+* Remove the purple border that surrounds the page.
 * Hide the private browsing icon.
 
 These settings can be found in Zen's browser settings, in the 'Look and Feel' tab.

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/theme.json
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/theme.json
@@ -8,5 +8,5 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/image.png",
     "author": "danm36",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/preferences.json",
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/theme.json
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/theme.json
@@ -1,7 +1,7 @@
 {
     "id": "58649066-2b6f-4a5b-af6d-c3d21d16fc00",
     "name": "Private Mode Highlighting",
-    "description": "This theme adds a purple gradient and icon to the main toolbar of any private browsing window.",
+    "description": "This theme adds extra theming and an icon to the main toolbar of any private browsing window.",
     "homepage": "https://github.com/danm36/zen-browser-private-browsing-toolbar-highlighting",
     "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css",
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/readme.md",


### PR DESCRIPTION
This fix adds a more pleasant gradient for light mode users, and prevents the URL bar from overlapping the private mode icon should the browser width be too small or the URL bar be otherwise expanded.

Fixes danm36/zen-browser-private-browsing-toolbar-highlighting#1