### PR TITLE
Update theme: Vesper Dark

### DIFF
--- a/themes/17f70712-4530-42d0-ba0f-fa25bcbf2ddc/colors.json
+++ b/themes/17f70712-4530-42d0-ba0f-fa25bcbf2ddc/colors.json
@@ -2,6 +2,6 @@
     "isDarkMode": true,
     "primaryColor": "#FDC797",
     "secondaryColor": "#FFFFFF25",
-    "tertiaryColor": "#0E100E",
+    "tertiaryColor": "#101010",
     "colorsBorder": "#282828"
 }


### PR DESCRIPTION
Fixing the tertiary color that does not match the official color in the Vesper color scheme.

Here is the screenshot of the hex code of the color in the Vesper color scheme source code.
![image](https://github.com/user-attachments/assets/5aed784b-54f0-424b-8b85-9e4d493d213c)
