### PR TITLE
Update theme: Private Mode Highlighting

### DIFF
--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
@@ -5,14 +5,29 @@
  * The --pbmh prefix stands for Private Browsing Mode Highlighting.
  */
 
-:root {
-  --pbmh-private-browsing-mode-color: #25003E;
-  --pbmh-private-browsing-mode-border: hsl(from var(--pbmh-private-browsing-mode-color) h s calc(l + 20));
+ :root {
+  --pbmh-private-browsing-mode-base-color: #32064e;
 }
 
-[devtoolstheme=light] {
-  --pbmh-private-browsing-mode-color: #C080EB;
-  --pbmh-private-browsing-mode-border: hsl(from var(--pbmh-private-browsing-mode-color) h s calc(l - 20));
+@media (-moz-bool-pref: "uc.private-browsing-top-bar.use-zen-theme-color") { :root { --pbmh-private-browsing-mode-base-color: oklch(from var(--zen-primary-color) calc(l - 0.5) c h); } }
+
+@media (-moz-bool-pref: "uc.private-browsing-top-bar.color-blue") { :root { --pbmh-private-browsing-mode-base-color: oklch(from #aac7ff calc(l - 0.5) c h); } }
+@media (-moz-bool-pref: "uc.private-browsing-top-bar.color-teal") { :root { --pbmh-private-browsing-mode-base-color: oklch(from #74d7cb calc(l - 0.5) c h); } }
+@media (-moz-bool-pref: "uc.private-browsing-top-bar.color-green") { :root { --pbmh-private-browsing-mode-base-color: oklch(from #a0d490 calc(l - 0.5) c h); } }
+@media (-moz-bool-pref: "uc.private-browsing-top-bar.color-yellow") { :root { --pbmh-private-browsing-mode-base-color: oklch(from #dec663 calc(l - 0.5) c h); } }
+@media (-moz-bool-pref: "uc.private-browsing-top-bar.color-orange") { :root { --pbmh-private-browsing-mode-base-color: oklch(from #ffb787 calc(l - 0.5) c h); } }
+@media (-moz-bool-pref: "uc.private-browsing-top-bar.color-brown") { :root { --pbmh-private-browsing-mode-base-color: oklch(from #dec1b1 calc(l - 0.5) c h); } }
+@media (-moz-bool-pref: "uc.private-browsing-top-bar.color-red") { :root { --pbmh-private-browsing-mode-base-color: oklch(from #ffb1c0 calc(l - 0.5) c h); } }
+@media (-moz-bool-pref: "uc.private-browsing-top-bar.color-pink") { :root { --pbmh-private-browsing-mode-base-color: oklch(from #f6b0ea calc(l - 0.5) c h); } }
+
+:root {
+  --pbmh-private-browsing-mode-color: var(--pbmh-private-browsing-mode-base-color);
+  --pbmh-private-browsing-mode-border: oklch(from var(--pbmh-private-browsing-mode-color) calc(l + 0.2) c h);
+
+  &:where([lwt-toolbar="light"]) {
+    --pbmh-private-browsing-mode-color: oklch(from var(--pbmh-private-browsing-mode-base-color) calc(l + 0.45) calc(c + 0.05) h);
+    --pbmh-private-browsing-mode-border: oklch(from var(--pbmh-private-browsing-mode-color) calc(l - 0.2) c h);
+  }
 }
 
 @media not (-moz-bool-pref: "uc.private-browsing-top-bar.no-bg") {
@@ -45,13 +60,17 @@
     content: "";
     position: absolute;
     left: 100%;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-image: url("chrome://global/skin/icons/indicator-private-browsing.svg");
+    top: 0.5rem;
+    bottom: 0.5rem;
+    aspect-ratio: 1;
+    width: auto;
+    height: auto;
+    border-radius: 100%;
+    background-color: oklch(from var(--pbmh-private-browsing-mode-base-color) calc(l + 0.05) calc(c + 0.2) h);
+    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48c3ZnIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZGVmcz48c3R5bGU+KntmaWxsOm5vbmU7c3Ryb2tlOiNGRkZGRkY7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjEuOTJweDt9PC9zdHlsZT48L2RlZnM+PHBvbHlsaW5lIHBvaW50cz0iMC41IDExLjA0IDEyIDExLjA0IDIzLjUgMTEuMDQiLz48cGF0aCBkPSJNMTkuNjcsMTFINC4zM0w1LDQuNjhBMi41NCwyLjU0LDAsMCwxLDcuNTcsMi40MmgwYTIuNDcsMi40NywwLDAsMSwxLjEzLjI3aDBhNy40Myw3LjQzLDAsMCwwLDYuNiwwaDBhMi40NywyLjQ3LDAsMCwxLDEuMTMtLjI3aDBBMi41NCwyLjU0LDAsMCwxLDE5LDQuNjhaIi8+PGNpcmNsZSBjeD0iNi43MyIgY3k9IjE4LjIzIiByPSIzLjM1Ii8+PGNpcmNsZSBjeD0iMTcuMjciIGN5PSIxOC4yMyIgcj0iMy4zNSIvPjxwYXRoIGQ9Ik0xMC4wOCwxOC43MWExLjkyLDEuOTIsMCwxLDEsMy44NCwwIi8+PGxpbmUgeDE9IjEuNDYiIHkxPSIxNS44MyIgeDI9IjQuMzMiIHkyPSIxNS44MyIvPjxsaW5lIHgxPSIxOS42NyIgeTE9IjE1LjgzIiB4Mj0iMjIuNTQiIHkyPSIxNS44MyIvPjwvc3ZnPg==");
     background-repeat: no-repeat;
     background-position: center center;
-    background-size: 70%;
+    background-size: 65%;
     pointer-events: none;
   }
 

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
@@ -1,6 +1,6 @@
 /**
  * This Zen theme adds additional styling to the private browsing mode window such as a gradient on the toolbar,
- * a border around the browser page, and an icon in the URL bar. These are configurable in Zen's Look and Feel settings.
+ * a border around the browser page, and an icon in the URL bar. These are configurable in Zen's Theme Store settings.
  *
  * The --pbmh prefix stands for Private Browsing Mode Highlighting.
  */

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/preferences.json
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/preferences.json
@@ -1,6 +1,15 @@
 {
-    "uc.private-browsing-top-bar.solid-bg": "Replaces the purple gradient on the toolbar with a solid purple color", 
-    "uc.private-browsing-top-bar.no-bg": "Removes the background color on the toolbar entirely", 
-    "uc.private-browsing-top-bar.no-border": "Removes the purple border that surrounds the page",
-    "uc.private-browsing-top-bar.hide-icon": "Hides the private browsing icon"
+    "uc.private-browsing-top-bar.solid-bg": "Replaces the gradient on the toolbar with a solid color.", 
+    "uc.private-browsing-top-bar.no-bg": "Removes the background color on the toolbar entirely.", 
+    "uc.private-browsing-top-bar.no-border": "Removes the colored border that surrounds the page.",
+    "uc.private-browsing-top-bar.use-zen-theme-color": "Use the Zen theme color as the highlight color.",
+    "uc.private-browsing-top-bar.color-blue": "Use a blue color as the highlight color. Overrides any ticked colors above this setting.",
+    "uc.private-browsing-top-bar.color-teal": "Use a teal color as the highlight color. Overrides any ticked colors above this setting.",
+    "uc.private-browsing-top-bar.color-green": "Use a green color as the highlight color. Overrides any ticked colors above this setting.",
+    "uc.private-browsing-top-bar.color-yellow": "Use a yellow color as the highlight color. Overrides any ticked colors above this setting.",
+    "uc.private-browsing-top-bar.color-orange": "Use a orange color as the highlight color. Overrides any ticked colors above this setting.",
+    "uc.private-browsing-top-bar.color-brown": "Use a brown color as the highlight color. Overrides any ticked colors above this setting.",
+    "uc.private-browsing-top-bar.color-red": "Use a red color as the highlight color. Overrides any ticked colors above this setting.",
+    "uc.private-browsing-top-bar.color-pink": "Use a pink color as the highlight color. Overrides any ticked colors above this setting.",
+    "uc.private-browsing-top-bar.hide-icon": "Hides the private browsing icon."
 }

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/readme.md
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/readme.md
@@ -17,6 +17,6 @@ It also comes with three settings:
 * Remove the purple border that surrounds the page.
 * Hide the private browsing icon.
 
-These settings can be found in Zen's browser settings, in the 'Look and Feel' tab.
+These settings can be found in Zen's browser settings, in the 'Theme Store' tab.
 
 Encountered an issue? Raise them [here](https://github.com/danm36/zen-browser-private-browsing-toolbar-highlighting/issues).

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/readme.md
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/readme.md
@@ -10,11 +10,12 @@ By default, this theme:
 * Adds a purple border surrounding the page.
 * Adds a private browsing icon to the right of the refresh button.
 
-It also comes with three settings:
+It also comes with the following settings:
 
 * Replace the gradient with a solid purple color.
 * Remove the background color entirely.
 * Remove the purple border that surrounds the page.
+* Changes the purple highlight color to either match Zen's theme color, or a custom color of your choice.
 * Hide the private browsing icon.
 
 These settings can be found in Zen's browser settings, in the 'Theme Store' tab.

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/theme.json
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/theme.json
@@ -8,5 +8,5 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/image.png",
     "author": "danm36",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/preferences.json",
-    "version": "1.0.1"
+    "version": "1.0.2"
 }


### PR DESCRIPTION
Adds the ability to have the private mode colors track Zen's theme color, or choose one of a fixed selection. In addition, the private mode icon now also tracks this color.

Ideally, at some point, Zen's preferences could gain the ability to choose a particular preference type and editor control, and then we can let the user pick their own color, adding the necessary CSS variable as required. If this feature gets added to Zen, then all the additional color choices will be removed at a future date.

Resolves https://github.com/danm36/zen-browser-private-browsing-toolbar-highlighting/issues/2