### PR TITLE
Apply only on about:newtab and about:home

### DIFF
--- a/themes/6a5e8204-ea7f-4c3d-a6fc-de503b470d70/chrome.css
+++ b/themes/6a5e8204-ea7f-4c3d-a6fc-de503b470d70/chrome.css
@@ -1,34 +1,35 @@
-
-.top-site-outer {
-	--tile-radius: 12px;
-	--tile-icon-size: 32px;
-	--tile-size: 56px;
-	border-radius: 16px !important;
-}
-.top-site-outer .tile {
-	border-radius: var(--tile-radius) !important;
-	height: var(--tile-size) !important;
-	width: var(--tile-size) !important;
-}
-.top-site-outer .tile .icon-wrapper {
-	width: var(--tile-icon-size) !important;
-	height: var(--tile-icon-size) !important;
-}
-.top-site-outer .tile .icon-wrapper.letter-fallback::before {
-	font-size: 32px !important;
-	top: 0 !important;
-}
-.top-site-outer .context-menu-button {
-	--tile-btn-size: 24px;
-	--tile-btn-radius: 8px;
-	border-radius: 0 !important;
-}
-.top-site-outer .context-menu-button {
-	background-color: var(--newtab-element-hover-color) !important;
-	padding: 1.5ch !important;
-	height: var(--tile-btn-size) !important;
-	width: var(--tile-btn-size) !important;
-	border-radius: var(--tile-btn-radius) !important;
-	right: 0 !important;
-	top: -12px !important;
+@-moz-document url("about:newtab"), url("about:home") {
+	.top-site-outer {
+		--tile-radius: 12px;
+		--tile-icon-size: 32px;
+		--tile-size: 56px;
+		border-radius: 16px !important;
+	}
+	.top-site-outer .tile {
+		border-radius: var(--tile-radius) !important;
+		height: var(--tile-size) !important;
+		width: var(--tile-size) !important;
+	}
+	.top-site-outer .tile .icon-wrapper {
+		width: var(--tile-icon-size) !important;
+		height: var(--tile-icon-size) !important;
+	}
+	.top-site-outer .tile .icon-wrapper.letter-fallback::before {
+		font-size: 32px !important;
+		top: 0 !important;
+	}
+	.top-site-outer .context-menu-button {
+		--tile-btn-size: 24px;
+		--tile-btn-radius: 8px;
+		border-radius: 0 !important;
+	}
+	.top-site-outer .context-menu-button {
+		background-color: var(--newtab-element-hover-color) !important;
+		padding: 1.5ch !important;
+		height: var(--tile-btn-size) !important;
+		width: var(--tile-btn-size) !important;
+		border-radius: var(--tile-btn-radius) !important;
+		right: 0 !important;
+		top: -12px !important;
+	}
 }


### PR DESCRIPTION
This reduces the scope of styles so that they apply only on Newtab page and Homepage. Homepage scope is needed when you have set Newtab as your homepage. If this is not done, the homepage will appear using unstyled newtab page when you open the browser.