### PR TITLE
Update Theme: SuperPins

### DIFF
--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
@@ -1,155 +1,105 @@
 @media (-moz-bool-pref: "zen.tabs.vertical") {
-  
-  /* Pins compact mode when toggled */
-  @media (-moz-bool-pref: "uc.pins.compact") {
-    :root {
-      --pinned-tabs-width: var(--tab-min-height);
-      --pinned-tabs-gap: 5px;
-      --pinned-tabs-height: 36px;
-    }
-  }
-  @media not (-moz-bool-pref: "uc.pins.compact") {
-    :root {
-      --pinned-tabs-width: calc(var(--tab-min-height) * 1.7);
-      --pinned-tabs-gap: 10px;
-    }
-  }
 
-  /* Make pinned tabs taller when toggled */
-  @media (-moz-bool-pref: "uc.pins.tall") and (-moz-bool-pref: "zen.view.sidebar-expanded") {
-    .tabbrowser-tab[pinned] { 
-      min-height: 43px !important;
-    }
-    @media (-moz-bool-pref: "uc.pins.compact") {
-      :root {
-        --pinned-tabs-width: 43px !important;
-      }
-    }
-  }
-  
-  /* Increase width of pinned tabs */
-  @media (-moz-bool-pref: "zen.view.sidebar-expanded") {
-    .scrollbox-clip > scrollbox {
-      grid-template-columns: repeat(auto-fill, minmax(var(--pinned-tabs-width), 1fr)) !important;
-      column-gap: var(--pinned-tabs-gap);
-    }
-    .tabbrowser-tab[pinned] {
-      margin-top: calc(var(--pinned-tabs-gap) / 2) !important;
-      margin-bottom: calc(var(--pinned-tabs-gap) / 2) !important;
-    }
-  }
-  
-  
-  /* COLORS of pinned tabs */
-
-  @media not (-moz-bool-pref: "uc.pins.disable-bg-color") {
+  /* COLOR POP of pinned tabs (when toggled) */
+  @media (-moz-bool-pref: "uc.pins.bg-color.pop") and (not (-moz-bool-pref: "uc.pins.disable-bg-color")) {
     /* background color of pinned tabs in a normal state (not hovered/selected) */
     .tabbrowser-tab[pinned] {
-      background-color: light-dark(color-mix(in srgb, var(--toolbarbutton-hover-background), #ffffff 12%), color-mix(in srgb, var(--toolbarbutton-hover-background), #000000 30%)) !important;
+      background-color: light-dark(hsl(from var(--zen-primary-color) h 70% 92%), hsl(from var(--zen-primary-color) h 25% 15%)) !important;
       border-radius: 8px !important;
     }
     /* background color when hovering */
-    .tabbrowser-tab[pinned]:hover {
-      background-color: light-dark(color-mix(in srgb, var(--toolbarbutton-hover-background), #000000 2%), color-mix(in srgb, var(--toolbarbutton-hover-background), #000000 20%)) !important;
-    }  
+    .tabbrowser-tab[pinned]:hover{
+      background-color: light-dark(hsl(from var(--zen-primary-color) h 70% 90%), hsl(from var(--zen-primary-color) h 25% 17%)) !important;
+    }
     /* background color when selected */
     .tabbrowser-tab[pinned][selected="true"],
     .tabbrowser-tab[pinned][multiselected="true"] {
-      background-color: light-dark(color-mix(in srgb, var(--toolbarbutton-hover-background), #000000 6%), color-mix(in srgb, var(--toolbarbutton-hover-background), #000000 0%)) !important;
+      background-color: light-dark(hsl(from var(--zen-primary-color) h 70% 85%), hsl(from var(--zen-primary-color) h 25% 28%)) !important;
     }
     /* background color when hovering and selected */
     .tabbrowser-tab[pinned][selected="true"]:hover,
-    .tabbrowser-tab[pinned][multiselected="true"]:hover {
-      background-color: light-dark(color-mix(in srgb, var(--toolbarbutton-hover-background), #000000 8%), color-mix(in srgb, var(--toolbarbutton-hover-background), #ffffff 5%)) !important;
-    }
-
-    @media (-moz-bool-pref: "uc.pins.bg-color.pop") {
-      /* background color of pinned tabs in a normal state (not hovered/selected) */
-      .tabbrowser-tab[pinned] {
-        background-color: light-dark(hsl(from var(--zen-primary-color) h 70% 90%), hsl(from var(--zen-primary-color) h 25% 20%)) !important;
-        border-radius: 8px !important;
-      }
-      /* background color when hovering */
-      .tabbrowser-tab[pinned]:hover{
-        background-color: light-dark(hsl(from var(--zen-primary-color) h 70% 88%), hsl(from var(--zen-primary-color) h 25% 22%)) !important;
-      }
-      /* background color when selected */
-      .tabbrowser-tab[pinned][selected="true"],
-      .tabbrowser-tab[pinned][multiselected="true"] {
-        background-color: light-dark(hsl(from var(--zen-primary-color) h 70% 83%), hsl(from var(--zen-primary-color) h 25% 35%)) !important;
-      }
-      /* background color when hovering and selected */
-      .tabbrowser-tab[pinned][selected="true"]:hover,
-      .tabbrowser-tab[pinned][multiselected="true"]:hover{
-        background-color: light-dark(hsl(from var(--zen-primary-color) h 70% 81%), hsl(from var(--zen-primary-color) h 25% 37%)) !important;
-      }
-    }  
-  }
-  
-
-  /* Hide seperator line above first normal tab when toggled on */
-  @media (-moz-bool-pref: "uc.hide-seperator-line") {
-    #tabbrowser-tabs:has(.tabbrowser-tab[pinned]) .tabbrowser-tab:nth-child(1 of [fadein]:not([pinned]):not([hidden])) {
-      margin-top: var(--pinned-tabs-gap) !important;
-      overflow: hidden !important;
+    .tabbrowser-tab[pinned][multiselected="true"]:hover{
+      background-color: light-dark(hsl(from var(--zen-primary-color) h 70% 83%), hsl(from var(--zen-primary-color) h 25% 30%)) !important;
     }
   }
-
-  /* Align tab bar with nav bar when not in compact mode when toggled on */
-  @media (-moz-bool-pref: "uc.tabs.align-with-navbar") and (not (-moz-bool-pref: "zen.view.compact")) {
-
-    @media not (-moz-bool-pref: "zen.themes.tabs.legacy-location") {
-      #tabbrowser-arrowscrollbox {
-        margin-top: 0 !important;
-      }
-      .scrollbox-clip > scrollbox {
-        padding-top: 0 !important;
-      }
-      .tabbrowser-tab[pinned] {
-        margin-top: calc((var(--pinned-tabs-gap) / 2) - 3px) !important;
-        margin-bottom: calc((var(--pinned-tabs-gap) / 2) + 3px) !important;
-      }
-      @media (-moz-bool-pref: "uc.pins.compact") {
-        .tabbrowser-tab[pinned] {
-          margin-top: calc((var(--pinned-tabs-gap) / 2) - 1px) !important;
-          margin-bottom: calc((var(--pinned-tabs-gap) / 2) + 1px) !important;
-        }
-      }
-      @media not (-moz-bool-pref: "uc.pins.compact") {
-        #tabbrowser-tabs:has(.tabbrowser-tab[pinned]) .tabbrowser-tab:nth-child(1 of [fadein]:not([pinned]):not([hidden])) {
-          margin-top: calc(var(--pinned-tabs-gap) - 3px) !important;
-        }
-      }
-      @media not (-moz-bool-pref: "zen.view.sidebar-expanded") {
-        #tabbrowser-tabs:has(.tabbrowser-tab[pinned]) .tabbrowser-tab:nth-child(1 of [fadein]:not([pinned]):not([hidden])) {
-          margin-top: 10px !important;
-        }
-      }
-    } 
-
-    @media (-moz-bool-pref: "zen.themes.tabs.legacy-location") {
-      #TabsToolbar {
-        padding-top: 0 !important;
-      }
-      @media (-moz-bool-pref: "uc.workspace-button.move-to-bottom") {
-        #tabbrowser-arrowscrollbox {
-          margin-top: 0 !important;
-        }
-        .scrollbox-clip > scrollbox {
-          padding-top: 0 !important;
-        }
-      }
+    
+  /* Makes pinned tabs transparent (when toggled) */
+  @media (-moz-bool-pref: "uc.pins.disable-bg-color") {
+    .tabbrowser-tab[pinned]:not(:hover):not([selected="true"]) {
+      background-color: transparent !important;
     }
   }
   
-  /* Remove the border of the workspace button if enabled when toggled on */
-  @media (-moz-bool-pref: "uc.workspace-button.remove-border") {
-    #zen-workspaces-button {
-      border: hidden !important;
+  /* Make new tabs button transparent (when toggled) */
+  @media (-moz-bool-pref: "uc.new-tab-button.transparent") {
+    #vertical-tabs-newtab-button:not(:hover) {
+      background-color: transparent !important;
     }
   }
   
-  /* Move workspace button to the bottom if enabled when toggled on */
+  /* Make pinned tabs taller (when toggled) */
+  @media (-moz-bool-pref: "uc.pins.tall") and (-moz-bool-pref: "zen.view.sidebar-expanded") and (not (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover")) {
+    .tabbrowser-tab[pinned] { 
+      min-height: 43px !important;
+    }
+  }  
+  
+  /* Set margin between pinned tabs (when toggled) */
+  @media (-moz-bool-pref: "uc.pins.margins.compact") {
+    :root {
+      --pins-gap: 5px;
+    }
+  }
+  @media (not (-moz-bool-pref: "uc.pins.margins.compact")) {
+    :root {
+      --pins-gap: 10px;
+    }
+  }
+
+  /* Increase width of pinned tabs */
+  @media (not (-moz-bool-pref: "uc.pins.wide.disabled")) and (-moz-bool-pref: "zen.view.sidebar-expanded") and (not (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover")) { 
+    #vertical-pinned-tabs-container {
+      grid-template-columns: repeat(auto-fit, minmax(68px, auto)) !important;
+      gap: var(--pins-gap) var(--pins-gap) !important;
+    }
+    /* Make gap between new tabs button and pins consistent */
+    #vertical-tabs-newtab-button {
+      margin-top: 5px !important;
+    }
+  }
+
+  /* Increase width of pinned tabs when expand on hover toggled */
+  @media (-moz-bool-pref: "zen.view.sidebar-expanded") and (not (-moz-bool-pref: "uc.pins.wide.disabled")) {  
+    #navigator-toolbox:is(
+      #navigator-toolbox[zen-user-hover="true"]:hover,
+      #navigator-toolbox[zen-user-hover="true"]:focus-within,
+      #mainPopupSet[zen-user-hover="true"]:has(> #appMenu-popup:hover) ~ toolbox,
+      #navigator-toolbox[zen-user-hover="true"]:has(*[open="true"]:not(tab):not(#zen-sidepanel-button)), 
+      :not([zen-user-hover="true"])) {
+        #vertical-pinned-tabs-container {
+          grid-template-columns: repeat(auto-fit, minmax(68px, auto)) !important;
+          gap: var(--pins-gap) var(--pins-gap) !important;
+        }
+        @media (-moz-bool-pref: "uc.pins.tall") {
+          .tabbrowser-tab[pinned] { 
+            min-height: 43px !important;
+          }
+        }
+        /* Make gap between new tabs button and pins consistent */
+        #vertical-tabs-newtab-button {
+          margin-top: 5px !important;
+        }
+    }
+  }
+  
+  /* Hides the separator line between pinned tabs and normal ones (when toggled) */
+  @media (-moz-bool-pref: "uc.separator-line.hide") {
+    #newtab-button-container::before {
+      width: 0 !important;
+    }
+  }
+  
+  /* Move workspace button to the bottom (when toggled) */
   @media (-moz-bool-pref: "uc.workspace-button.move-to-bottom") {
     #zen-workspaces-button {
       order: 1;
@@ -163,18 +113,60 @@
     }
   }
   
-  /* Stop Zen toolbar from greying out when losing focus when toggled on */
-  @media (-moz-bool-pref: "uc.zen-toolbar-opacity") {
-    :root {
-      --inactive-titlebar-opacity: 1 !important;
+  /* Hides unloaded tabs when tab bar is collapsed (when toggled)*/
+  @media (-moz-bool-pref: "uc.pins.only-show-active") and (not (-moz-bool-pref: "zen.view.sidebar-expanded")) {
+    .tabbrowser-tab[pinned][pending="true"] {
+      position: absolute !important; /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
+      visibility: hidden !important;
+    }
+    /* Shows all pins when user is hovering over them when tab bar is collapsed */
+    @media (-moz-bool-pref: "uc.pins.only-show-active.on-hover") {
+      #vertical-pinned-tabs-container:hover .tabbrowser-tab[pinned][pending="true"] {
+        position: relative !important;
+        visibility: visible !important;
+      }
+
+      #vertical-pinned-tabs-container {
+        position: relative;
+      }
+
+      #vertical-pinned-tabs-container::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 10px;
+        background-color: transparent;
+      }
+
+      #vertical-pinned-tabs-container::before:hover .tabbrowser-tab[pinned][pending="true"] {
+        position: relative !important;
+        visibility: visible !important;
+      }
     }
   }
-
-  /* Add some space above/below pinned tabs when only icon visible -> tabbar not expanded */
-  @media not (-moz-bool-pref: "zen.view.sidebar-expanded") {
-    .tabbrowser-tab[pinned] {
-      margin-top: 2px !important;
-      margin-bottom: 4px !important;
+  
+  /* Hides unloaded tabs when tab bar is collapsed when in "Expand on hove" mode (when toggled)*/
+  @media (-moz-bool-pref: "uc.pins.only-show-active"){  
+  #navigator-toolbox:not(
+    :is(
+    #navigator-toolbox[zen-user-hover="true"]:hover,
+    #navigator-toolbox[zen-user-hover="true"]:focus-within,
+    #mainPopupSet[zen-user-hover="true"]:has(> #appMenu-popup:hover) ~ toolbox,
+    #navigator-toolbox[zen-user-hover="true"]:has(*[open="true"]:not(tab):not(#zen-sidepanel-button)), 
+    :not([zen-user-hover="true"]))) {
+      .tabbrowser-tab[pinned][pending="true"] {
+        position: absolute !important; /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
+        visibility: hidden !important;
+      }
+    }
+  }
+  
+  /* Remove the border of the workspace button if enabled (when toggled) */
+  @media (-moz-bool-pref: "uc.workspace-button.remove-border") {
+    #zen-workspaces-button {
+      border: hidden !important;
     }
   }
 }

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
@@ -1,13 +1,15 @@
 {
-    "browser.sessionstore.restore_pinned_tabs_on_demand": "Stop Zen from loading all pinned tabs on startup, instead load pinned tabs on demand",
-    "zen.tabs.dim-pending": "Uncheck to stop Zen from dimming unloaded tabs",
-    "uc.zen-toolbar-opacity": "Stop Zen from decreasing opacity/greying out when Zen windows loses focus",
-    "uc.hide-seperator-line": "Hides the seperator line between pinned tabs and the first normal tab",
-    "uc.tabs.align-with-navbar": "Aligns the tabs with the navbar",
+    "uc.pins.wide.disabled": "Disables the layout changes made by SuperPins",
+    "uc.pins.tall": "Increases the height of pinned tabs (Disabled when tab bar not expanded)",
+    "uc.pins.margins.compact": "Decreases the gap between pinned tabs",
+    "uc.pins.only-show-active": "Only shows loaded tabs when the tab bar is collapsed",
+    "uc.pins.only-show-active.on-hover": "Only shows loaded tabs when the tab bar is collapsed, except when hovering over them (Only works with the above option enabled!)",
+    "uc.pins.bg-color.pop": "Makes the colors of pinned tabs pop more",
+    "uc.pins.disable-bg-color": "Disables the background color of pinned tabs",
+    "uc.new-tab-button.transparent": "Makes the new tabs button transparent",
+    "uc.separator-line.hide": "Hides the seperator line between pinned tabs and the first normal tab",
     "uc.workspace-button.remove-border": "Removes the border of the workspace button",
     "uc.workspace-button.move-to-bottom": "Moves the workspace button to the bottom of the tab bar",
-    "uc.pins.disable-bg-color": "Disables the background color of pinned tabs",
-    "uc.pins.bg-color.pop": "This makes the colors of pinned tabs pop more",
-    "uc.pins.tall": "This makes the pinned tabs a bit taller (Disabled when tab bar not expanded)",
-    "uc.pins.compact": "This makes the pinned tabs more compact by decreasing their width and the gap inbetween them"
+    "browser.sessionstore.restore_pinned_tabs_on_demand": "Loads pinned tabs only when using them, instead of loading all of them on startup",
+    "zen.tabs.dim-pending": "Dims unloaded tabs"
 }

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md
@@ -3,20 +3,18 @@
 This **Zen theme** elevates your experience with pinned tabs and the tab bar in general by making some UI changes, inspired by the favorites in Arc.
 
 ## What it does by default:
-  - Increases the size of pinned tabs
-  - Adds a background color (according to your accent color set in *Settings -> Look and Feel -> Theme Color*)
-    (This can be toggled off)
-  - Adds some space between the pinned tabs
+  - Increases the width of pinned tabs (This can be toggled off)
+  - Adds a universal gap between the pinned tabs (Gap size can be controlled)
 
 ## Optional Features (toggle in Zen's theme settings):
-  - Stop Zen from loading all pinned tabs on startup
-  - Stop Zen from dimming unloaded tabs
-  - Stop Zen from decreasing opacity/greying out toolbar when Zen windows loses focus
-  - Align tabs with navbar
-  - Center all tabs and workspace button when tab bar is expanded
+  - Taller pinned tabs
+  - Smaller Margins between pinned tabs (5px or 10px)
+  - Hide unloaded pinned tabs when tab bar is collapsed (Additional option: Show all pinned tabs on hover even with tab bar collapsed)
+  - Color pop for pinned tabs (according to your accent color set in *Settings -> Look and Feel -> Theme Color*)
+  - Make pinned tabs transparent
+  - Make the new tabs button transparent
+  - Hide the separator line between pinned tabs and normal tabs
   - Remove the border of the workspace button
   - Move workspace button to the bottom of the tabbar
-  - Hide seperator line between pinned tabs and normal tabs
-  - Color pop for pinned tabs
-  - Taller pinned tabs
-  - Compact mode for pinned tabs
+  - Load pinned tabs only when using them, instead of loading all of them on startup
+  - Dim unloaded tabs

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
@@ -7,6 +7,6 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/image.png",
     "author": "JLBlk",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json"
 }


### PR DESCRIPTION
- Added compatibility with Zen's a35 and a37 Update
    - Fixed margins
    - Fixed grid layout
    - Fixed "Hide separator line" option
    - Removed align with navbar
    - Changed compact mode option to only decrease gap between pins instead of making them smaller too

- Added option to disable SuperPins Layout
- Added option to make new tabs button transparent
- Added option to hide unloaded pinned tabs when tab bar is collapsed while showing all pins when tab bar is expanded https://github.com/JLBlk/Zen-Themes/issues/7  (thx Mnosz for the idea!)
    - Added additional option to show all pinned tabs on hover when the above option is enabled
- Removed natively implemented features
- Fixed https://github.com/JLBlk/Zen-Themes/issues/5
- Increased version to 1.3.0