### PR TITLE
Update Theme: Hide tab mute

### DIFF
--- a/themes/053a3ffa-9233-4554-88f3-076e6a6ebb43/chrome.css
+++ b/themes/053a3ffa-9233-4554-88f3-076e6a6ebb43/chrome.css
@@ -1,6 +1,10 @@
-
 @media not (-moz-bool-pref: "zen.view.sidebar-expanded") {
-    .tab-icon-overlay:is([soundplaying], [muted], [activemedia-blocked]) {
-        display: none !important;
-    }
+  .tab-icon-overlay:is([soundplaying],
+  [muted],
+  [activemedia-blocked]) {
+    display: none !important;
+  }
+  .tab-icon-image {
+    opacity: 1 !important;
+  }
 }

--- a/themes/053a3ffa-9233-4554-88f3-076e6a6ebb43/theme.json
+++ b/themes/053a3ffa-9233-4554-88f3-076e6a6ebb43/theme.json
@@ -7,5 +7,5 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/053a3ffa-9233-4554-88f3-076e6a6ebb43/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/053a3ffa-9233-4554-88f3-076e6a6ebb43/image.png",
     "author": "Tc-001",
-    "version": "1.0.0"
+    "version": "1.0.1"
 }


### PR DESCRIPTION
New browser versions hides the favicon on hover to show the mute button. As there is no mute button to show, this forces the favicon to always be visible.

Note: `.tab-icon-image` is quite an unspecific selector, but I don't believe that should cause any visual issues with other parts of the UI, as opacity is rarely used. Let me know if this is an issue and I can narrow it down!