### PR TITLE
Update Theme: Super Url Bar

### DIFF
--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/chrome.css
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/chrome.css
@@ -1,29 +1,29 @@
 /* Adjust border radius of url bar and its elements */
 @media (-moz-bool-pref: "uc.urlbar.border-radius") {
   #urlbar {
-    border-radius: 10px !important;
+    border-radius: 20px !important;
   }
           
   #notification-popup-box {
-    border-radius: 6px !important;
+    border-radius: 20px !important;
   }
         
   /* Border radius on hover */
   #urlbar .urlbar-page-action, #urlbar #tracking-protection-icon-container, #urlbar:not([breakout-extend="true"]) #identity-box:is(:not(.chromeUI), [pageproxystate="invalid"]) #identity-icon-box {
-    border-radius: 6px !important;;
+    border-radius: 20px !important;;
   }
         
   /* Border radius of boxes on the left */
   #identity-box:has(#identity-permission-box:is([hasPermissions], [hasSharingIcon])):not([pageproxystate="invalid"]) #identity-icon-box {
-    border-top-left-radius: 6px !important;
-    border-bottom-left-radius: 6px !important;
+    border-top-left-radius: 20px !important;
+    border-bottom-left-radius: 20px !important;
     border-top-right-radius: 0 !important;
     border-bottom-right-radius: 0 !important;
   }
 
   /* Extensions or similar */
   #urlbar:not([breakout-extend="true"]) #identity-box.chromeUI:not([pageproxystate="invalid"]) #identity-icon-box {
-    border-radius: 6px 6px 6px 6px !important;
+    border-radius: 20px 20px 20px 20px !important;
   }
 }
 
@@ -51,6 +51,13 @@
     backdrop-filter: blur(1px);
   
     z-index: -1;
+  }
+  
+  /* Scuffed af solution to make blur work (need to find better solution)*/
+  :root:not([inDOMFullscreen='true']):not([chromehidden~='location']):not([chromehidden~='toolbar']) {
+    & #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+      clip-path: inset(-5px -5px -5px round var(--zen-webview-border-radius, var(--zen-border-radius)));
+    }
   }
 }
 

--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/readme.md
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/readme.md
@@ -1,7 +1,7 @@
 # Super Url Bar
 
 ## This **Zen theme** gives you 4 optional settings (in Zen's theme settings):
-  - Adjust border radius of url bar (Rounded edges)
+  - Adjust border radius of url bar (Circle like corners)
   - Center url text
   - Remove the border of the url bar
   - Blur the background when the url bar is in focus

--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/theme.json
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/theme.json
@@ -7,6 +7,6 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/image.png",
     "author": "JLBlk",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/preferences.json"
 }


### PR DESCRIPTION
Quick Fixes after Zens latest update:
- Make border radius option to create circle like corners (like in og zen) 
- Fixed blur not working (scuffed af solution, uses clip path like in og zen (was the only way i found how to fix it for now) I really need to find a better solution)
- Increased version to 1.1.1