### PR TITLE
Update Theme: Super Url Bar

### DIFF
--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/chrome.css
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/chrome.css
@@ -27,9 +27,14 @@
   }
 }
 
-/* Centers the url text if toggled */
-@media (-moz-bool-pref: "uc.urltext.center") {
-  #urlbar:not([focused]) .urlbar-input{
+/* Centers the url text when enabled in dropdown: 1.Option: Centers the text unless url bar is focused; 2.Option: Centers the text always*/
+:root:has(#theme-Super-Url-Bar[uc-urltext-center="normal"]) {
+  #urlbar:not([focused]) .urlbar-input {
+    text-align: center !important; 
+  }
+}
+:root:has(#theme-Super-Url-Bar[uc-urltext-center="advanced"]) {
+  #urlbar .urlbar-input {
     text-align: center !important; 
   }
 }
@@ -53,11 +58,9 @@
     z-index: -1;
   }
   
-  /* Scuffed af solution to make blur work (need to find better solution)*/
+  /* Scuffed af solution to make blur work (need to find better solution) */
   :root:not([inDOMFullscreen='true']):not([chromehidden~='location']):not([chromehidden~='toolbar']) {
-    & #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
-      clip-path: inset(-5px -5px -5px round var(--zen-webview-border-radius, var(--zen-border-radius)));
-    }
+    clip-path: inset(0 round var(--zen-webview-border-radius, var(--zen-border-radius)));
   }
 }
 
@@ -65,5 +68,32 @@
 @media (-moz-bool-pref: "uc.urlbar.border.removed") {
   #urlbar {
     border: none !important;
+  }
+}
+
+/* Removes certain buttons from the url bar (when toggled) */
+@media (-moz-bool-pref: "uc.urlbar.icon.zoom.removed") {
+  #urlbar-zoom-button {
+    display: none !important;
+  }
+}
+@media (-moz-bool-pref: "uc.urlbar.icon.shield.removed") {
+  #tracking-protection-icon-container {
+    display: none !important;
+  }
+}
+@media (-moz-bool-pref: "uc.urlbar.icon.bookmark.removed") {
+  #star-button-box {
+    display: none !important;
+  }
+}
+@media (-moz-bool-pref: "uc.urlbar.icon.reader-mode.removed") {
+  #reader-mode-button {
+    display: none !important;
+  }
+}
+@media (-moz-bool-pref: "uc.urlbar.icon.pip.removed") {
+  #picture-in-picture-button {
+    display: none !important;
   }
 }

--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/preferences.json
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/preferences.json
@@ -8,8 +8,19 @@
     {
         "property": "uc.urltext.center",
         "label": "Centers the text inside the url bar",
-        "type": "checkbox",
-        "disabledOn": []
+        "type": "dropdown",
+        "defaultValue": "normal",
+        "disabledOn": [],
+        "options": [
+            {
+                "label": "Centered unless focused",
+                "value": "normal"
+            },
+            {
+                "label": "Always Centered",
+                "value": "advanced"
+            }
+        ]
     },
     {
         "property": "uc.urlbar.border.removed",
@@ -20,6 +31,36 @@
     {
         "property": "uc.urlbar.blur",
         "label": "Blurs the background when the url bar is in focus",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.urlbar.icon.zoom.removed",
+        "label": "Hides the Zoom icon",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.urlbar.icon.shield.removed",
+        "label": "Hides the Shield icon",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.urlbar.icon.bookmark.removed",
+        "label": "Hides the Bookmark (Star) icon",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.urlbar.icon.reader-mode.removed",
+        "label": "Hides the Reader-Mode icon",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.urlbar.icon.pip.removed",
+        "label": "Hides the Picture-in-Picture icon",
         "type": "checkbox",
         "disabledOn": []
     }

--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/readme.md
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/readme.md
@@ -1,7 +1,13 @@
 # Super Url Bar
 
 ## This **Zen theme** gives you 4 optional settings (in Zen's theme settings):
-  - Adjust border radius of url bar (Circle like corners)
+  - Adjust border radius of the url bar (Circle like corners)
   - Center url text
   - Remove the border of the url bar
   - Blur the background when the url bar is in focus
+  - Hide icons inside the url bar:
+    - Zoom icon
+    - Shield icon
+    - Bookmark (Star) icon
+    - Reader-Mode icon
+    - PiP icon

--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/theme.json
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/theme.json
@@ -7,6 +7,6 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/image.png",
     "author": "JLBlk",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/preferences.json"
 }


### PR DESCRIPTION
- Added options to hide certain url bar icons (Thanks kigeprak for the idea!):
  - Zoom Icon
  - Shield Icon
  - Bookmark Icon
  - Reader-Mode Icon
  - PiP Icon
- Turned center url text option into dropdown 
  - Added option to have url text always centered even when url is focused (https://github.com/JLBlk/Zen-Themes/issues/9)
- Increased Version to 1.2.0