### PR TITLE
Update Theme: SuperPins

### DIFF
--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
@@ -79,13 +79,21 @@
   }
   
   /* Hides unloaded tabs when tab bar is collapsed (when toggled)*/
-  @media (-moz-bool-pref: "uc.pins.only-show-active") and (not (-moz-bool-pref: "zen.view.sidebar-expanded")) {
-    .tabbrowser-tab[pinned][pending="true"] {
-      position: absolute !important; /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
-      visibility: hidden !important;
+  @media (not (-moz-bool-pref: "zen.view.sidebar-expanded")) {
+    :root:has(#theme-SuperPins[uc-pins-only-show-active="Normal"]) {
+      .tabbrowser-tab[pinned][pending="true"] {
+        position: absolute !important; /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
+        visibility: hidden !important;
+      }
     }
+
     /* Shows all pins when user is hovering over them when tab bar is collapsed */
-    @media (-moz-bool-pref: "uc.pins.only-show-active.on-hover") {
+    :root:has(#theme-SuperPins[uc-pins-only-show-active="OnHover"]) {
+      .tabbrowser-tab[pinned][pending="true"] {
+        position: absolute !important; /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
+        visibility: hidden !important;
+      }
+
       #vertical-pinned-tabs-container:hover .tabbrowser-tab[pinned][pending="true"] {
         position: relative !important;
         visibility: visible !important;

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
@@ -58,7 +58,7 @@
       :not([zen-user-hover="true"])) {
         #vertical-pinned-tabs-container {
           grid-template-columns: repeat(auto-fit, minmax(60px, auto)) !important;
-          gap: var(--pins-gap) var(--pins-gap) !important;
+          gap: var(--pins-gap) calc(var(--pins-gap) + 4px) !important;
         }
         @media (-moz-bool-pref: "uc.pins.tall") {
           .tabbrowser-tab[pinned] { 
@@ -66,33 +66,15 @@
           }
         }
     }
+    #vertical-pinned-tabs-container {
+      margin-bottom: var(--pins-gap) !important;
+    }
   }
   
   /* Make pinned tabs look more box like */
   @media (-moz-bool-pref: "uc.pins.box-like-corners") {
     .tabbrowser-tab[pinned] .tab-stack .tab-background{
       border-radius: 5px !important;
-    }
-  }
-  
-  /* Hides the separator line between pinned tabs and normal ones (when toggled) */
-  @media (-moz-bool-pref: "uc.separator-line.hide") {
-    #newtab-button-container::before {
-      width: 0 !important;
-    }
-  }
-  
-  /* Move workspace button to the bottom (when toggled) */
-  @media (-moz-bool-pref: "uc.workspace-button.move-to-bottom") {
-    #zen-workspaces-button {
-      order: 1;
-      margin-bottom: auto !important;
-    }
-    @media (-moz-bool-pref: "zen.view.sidebar-expanded") {
-      .tabbrowser-tab[pinned] {
-        margin-top: 0px !important;
-        margin-bottom: var(--pinned-tabs-gap) !important;
-      }
     }
   }
   
@@ -143,13 +125,6 @@
         position: absolute !important; /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
         visibility: hidden !important;
       }
-    }
-  }
-  
-  /* Remove the border of the workspace button if enabled (when toggled) */
-  @media (-moz-bool-pref: "uc.workspace-button.remove-border") {
-    #zen-workspaces-button {
-      border: hidden !important;
     }
   }
 }

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
@@ -25,15 +25,20 @@
     },
     {
         "property": "uc.pins.only-show-active",
-        "label": "Only shows loaded tabs when the tab bar is collapsed",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
-        "property": "uc.pins.only-show-active.on-hover",
-        "label": "Only shows loaded tabs when the tab bar is collapsed, except when hovering over them (Only works with the above option enabled!)",
-        "type": "checkbox",
-        "disabledOn": []
+        "label": "Only shows loaded pinned tabs (when the tab bar is collapsed)",
+        "type": "dropdown",
+        "disabledOn": [],
+        "options": 
+        [
+            {
+                "label": "Normal",
+                "value": "Normal"
+            },
+            {
+                "label": "Also show them on hover",
+                "value": "OnHover"
+            }
+        ]
     },
     {
         "property": "uc.pins.bg-color.pop",

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
@@ -48,24 +48,6 @@
         "disabledOn": []
     },
     {
-        "property": "uc.separator-line.hide",
-        "label": "Hides the seperator line between pinned tabs and the first normal tab",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
-        "property": "uc.workspace-button.remove-border",
-        "label": "Removes the border of the workspace button",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
-        "property": "uc.workspace-button.move-to-bottom",
-        "label": "Moves the workspace button to the bottom of the tab bar",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
         "property": "browser.sessionstore.restore_pinned_tabs_on_demand",
         "label": "Loads pinned tabs only when using them, instead of loading all of them on startup",
         "type": "checkbox",

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md
@@ -1,20 +1,17 @@
 # SuperPins
 
-This **Zen theme** elevates your experience with pinned tabs and the tab bar in general by making some UI changes, inspired by the favorites in Arc.
+This **Zen Mod** elevates your experience with pinned tabs and the tab bar in general by making some UI changes.
 
 ## What it does by default:
   - Increases the width of pinned tabs (This can be toggled off)
   - Adds a universal gap between the pinned tabs (Gap size can be controlled)
 
-## Optional Features (toggle in Zen's theme settings):
+## Optional Features (toggle in Zen's Mod settings):
   - Taller pinned tabs
-  - Smaller Margins between pinned tabs (5px or 10px)
+  - Controllable Margins between pinned tabs (5px or 10px)
   - Box like corners for pinned tabs (less rounded corners)
   - Hide unloaded pinned tabs when tab bar is collapsed (Additional option: Show all pinned tabs on hover even with tab bar collapsed)
   - Color pop for pinned tabs (according to your accent color set in *Settings -> Look and Feel -> Theme Color*)
   - Make pinned tabs transparent
-  - Hide the separator line between pinned tabs and normal tabs
-  - Remove the border of the workspace button
-  - Move workspace button to the bottom of the tabbar
   - Load pinned tabs only when using them, instead of loading all of them on startup
   - Dim unloaded tabs

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
@@ -1,12 +1,12 @@
 {
     "id": "ad97bb70-0066-4e42-9b5f-173a5e42c6fc",
     "name": "SuperPins",
-    "description": "This Zen theme enhances pinned tabs and the tab bar in general, inspired by the favorites in Arc.",
+    "description": "This Zen Mod enhances pinned tabs, by making some UI/UX changes.",
     "homepage": "https://github.com/JLBlk/Zen-Themes/tree/main/SuperPins",
     "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css",
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/image.png",
     "author": "JLBlk",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json"
 }


### PR DESCRIPTION
- Removed now unneeded options after zen update
- Fixed gaps to be universal (to be the same top/bottom and left/right)
- Turned Checkboxes into Dropdown for: Only show loaded pinned tabs when tab bar is collapsed
- Increased Version to 1.3.3