### PR TITLE
Update Theme: Only top bar in compact

### DIFF
--- a/themes/d8a9b9a4-30b7-48b5-99ad-448efa604f7e/chrome.css
+++ b/themes/d8a9b9a4-30b7-48b5-99ad-448efa604f7e/chrome.css
@@ -18,17 +18,14 @@
 #zen-appcontent-navbar-container:hover,
 #zen-appcontent-navbar-container:focus-within,
 #zen-appcontent-navbar-container[zen-user-show],
-#mainPopupSet:has(> #appMenu-popup:hover) ~ #zen-appcontent-navbar-container,
+#mainPopupSet:has(> #appMenu-popup:hover)~#zen-appcontent-navbar-container,
 #zen-appcontent-navbar-container:has(*[open="true"]) {
   transform: translateY(0);
   opacity: 1;
 }
 
 @media (-moz-bool-pref: "uc.only-top-bar-compact.top-margin-on-reduced.enabled") {
-  :root:not([inDOMFullscreen="true"])
-    #tabbrowser-tabbox
-    #tabbrowser-tabpanels
-    .browserSidebarContainer {
+  :root:not([inDOMFullscreen="true"]) #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     margin-top: var(--zen-element-separation) !important;
   }
 }
@@ -39,4 +36,8 @@
 
 #zen-sidebar-web-panel-wrapper {
   margin-top: 10px !important;
+}
+
+#tabbrowser-tabpanels {
+  padding-top: var(--zen-element-separation) !important;
 }


### PR DESCRIPTION
Fixed the top padding of the panel when compact top bar is enabled to be consistent with the padding of other margins.

Before:
![before](https://github.com/user-attachments/assets/92d357c1-e765-431a-921c-334a657dbfad)

After:
![after](https://github.com/user-attachments/assets/2c271f52-5506-4daa-812c-1d039ad19d51)
