### PR TITLE
Update theme: Private Mode Highlighting

### DIFF
--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/chrome.css
@@ -75,16 +75,16 @@
 \*******************************************/
 
 @media not (-moz-bool-pref: "uc.private-browsing-top-bar.hide-icon") {
-  [privatebrowsingmode] #stop-reload-button {
+  [privatebrowsingmode] #zen-profile-button {
     position: relative;
   }
 
-  [privatebrowsingmode] #stop-reload-button::after {
+  [privatebrowsingmode] #zen-profile-button::after {
     content: "";
     position: absolute;
-    left: calc(100% + 0.5em);
-    top: 1em;
-    bottom: 1em;
+    left: calc(100% + 1em);
+    top: 25%;
+    bottom: 25%;
     aspect-ratio: 1;
     width: auto;
     height: auto;
@@ -95,20 +95,5 @@
     background-position: center center;
     background-size: 65%;
     pointer-events: none;
-  }
-
-  /*
-   * Prevents the spring from collapsing too far and causing the URL bar to overlap the icon 
-   */
-  [privatebrowsingmode] toolbarspring:has(+ #urlbar-container) {
-    min-width: 40px !important;
-  }
-
-  /* 
-   *If the spring has been remvoed (e.g., the browser width is too small), 
-   *then add a margin to the URL bar to prevent it from overlapping the icon
-   */
-  [privatebrowsingmode] #stop-reload-button+#urlbar-container {
-    margin-inline-start: 40px !important;
   }
 }

--- a/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/theme.json
+++ b/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/theme.json
@@ -8,5 +8,5 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/image.png",
     "author": "danm36",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/58649066-2b6f-4a5b-af6d-c3d21d16fc00/preferences.json",
-    "version": "1.0.3"
+    "version": "1.0.4"
 }


### PR DESCRIPTION
This fixes where the private mode icon is located and its size to account for the (very nice) new layout of Zen 1.0.1-a3. It also removes a now unnecessary hack I had to apply to the URL bar to compensate for the icon's old position.