### PR TITLE
Update theme: Zen minimal exit menu 1.0.1

### DIFF
--- a/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/chrome.css
+++ b/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/chrome.css
@@ -1,4 +1,3 @@
-
 .titlebar-buttonbox {
     margin-right: 20px;
 }
@@ -8,28 +7,51 @@
     min-height: 13px !important;
     min-width: 13px !important;
     align-self: center;
-    background-color: hsl(0, 0%, 20%) !important;
     margin-left: 5px !important;
     border-radius: 50px;
     transition: all 100ms;
 }
 
-.titlebar-button:hover {
-    min-height: 20px !important;
-}
-
-.titlebar-min:hover {
+.titlebar-min {
     background-color: hsl(130, 50%, 40%) !important;
 }
 
-.titlebar-max:hover, .titlebar-restore:hover {
+.titlebar-max, .titlebar-restore {
     background-color: hsl(60, 50%, 50%) !important;
 }
 
-.titlebar-close:hover {
+.titlebar-close {
     background-color: hsl(0, 50%, 50%) !important;
 }
 
 .titlebar-button > image {
     visibility: collapse !important;
+}
+
+@media (-moz-bool-pref: "theme.zen-minimal-exit-menu.enable-macos-identic") {
+    .titlebar-button:hover {
+        opacity: 0.25 !important;
+    }
+}
+
+@media not (-moz-bool-pref: "theme.zen-minimal-exit-menu.enable-macos-identic") {
+    .titlebar-button {
+        background-color: var(--zen-colors-border) !important;
+    }
+    
+    .titlebar-min:hover {
+        background-color: hsl(130, 50%, 40%) !important;
+    }
+
+    .titlebar-max:hover, .titlebar-restore:hover {
+        background-color: hsl(60, 50%, 50%) !important;
+    }
+
+    .titlebar-close:hover {
+        background-color: hsl(0, 50%, 50%) !important;
+    }
+    
+    .titlebar-button:hover {
+        min-height: 20px !important;
+    }
 }

--- a/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/preferences.json
+++ b/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/preferences.json
@@ -1,0 +1,7 @@
+{
+    "property": "theme.zen-minimal-exit-menu.enable-macos-identic",
+    "label": "Makes theme more identical to MacOS version.",
+    "defaultValue": "false",
+    "disabledOn": ["macos"],
+    "type": "checkbox"
+}

--- a/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/theme.json
+++ b/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/theme.json
@@ -7,5 +7,5 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/image.png",
     "author": "Dinno-DEV",
-    "version": "1.0.0"
+    "version": "1.0.1"
 }


### PR DESCRIPTION
1. Allows the buttons to follow whatever themes the user is using. (Button's bg color is set to browser's border color)
2. Allows for a more identical MacOS exit menu.