### PR TITLE
Fix Theme Metadata Duplication and Add Missing Properties for Recent Pull Requests

### DIFF
--- a/.github/workflows/update-theme-date.yml
+++ b/.github/workflows/update-theme-date.yml
@@ -57,4 +57,5 @@ jobs:
             git add "themes/$theme/theme.json"
           done
           git commit -m "Update \`updated at\` field for \`$CHANGED_THEMES\`"
-          git push
+          git pull origin main --strategy-option=theirs
+          git push origin main

--- a/.github/workflows/update-theme-date.yml
+++ b/.github/workflows/update-theme-date.yml
@@ -1,13 +1,11 @@
 name: Update Theme Timestamps
 
 on:
-  pull_request:
-    branches:
-      - main
-    types: [closed]
   push:
     branches:
       - main
+    paths:
+      - 'themes/**'
 
 jobs:
   update-timestamp:

--- a/scripts/rebuild_themes.py
+++ b/scripts/rebuild_themes.py
@@ -75,11 +75,12 @@ def main():
                     if "tags" not in theme_data:
                         theme_data["tags"] = []
 
-                    # Add 'color theme' tag if colors.json is present
-                    theme_data["tags"].append("color theme")
+                    # Add 'color theme' tag if colors.json is present and tag isn't already in tags list
+                    if "color scheme" not in theme_data["tags"]:
+                        theme_data["tags"].append("color scheme")
 
-                    # Add 'dark' tag if colors.json specifies dark mode
-                    if "isDarkMode" in colors and colors["isDarkMode"]:
+                    # Add 'dark' tag if colors.json specifies dark mode and tag isn't already in tags list
+                    if "isDarkMode" in colors and colors["isDarkMode"] and "dark" not in theme_data["tags"]:
                         theme_data["tags"].append("dark")
                         
                 themes_data[theme] = theme_data

--- a/scripts/update_theme_date.py
+++ b/scripts/update_theme_date.py
@@ -33,6 +33,11 @@ def update_theme_date(theme_path):
     # Update the `updatedAt` field to the current date
     theme_data["updatedAt"] = current_date
     print(f"Updated `updatedAt` for {theme_path} to {theme_data['updatedAt']}")
+    
+    # Add `tags` as an empty list if it doesn't exist
+    if "tags" not in theme_data:
+        theme_data["tags"] = []
+        print(f"Initialized `tags` for {theme_path} as an empty list")
 
     # Write the changes back to theme.json
     with open(theme_file, "w") as f:

--- a/scripts/update_theme_date.py
+++ b/scripts/update_theme_date.py
@@ -21,9 +21,18 @@ def update_theme_date(theme_path):
             theme_data = json.load(f)
         except json.JSONDecodeError as e:
             panic("Error reading theme.json: " + str(e))
+            
+    # Get the current date
+    current_date = time.strftime("%Y-%m-%d")
+            
+    # Set `createdAt` to the current date if it doesn't exist
+    if "createdAt" not in theme_data:
+        theme_data["createdAt"] = current_date
+        print(f"Set `createdAt` for {theme_path} to {theme_data['createdAt']}")
 
     # Update the `updatedAt` field to the current date
-    theme_data["updatedAt"] = time.strftime("%Y-%m-%d")
+    theme_data["updatedAt"] = current_date
+    print(f"Updated `updatedAt` for {theme_path} to {theme_data['updatedAt']}")
 
     # Write the changes back to theme.json
     with open(theme_file, "w") as f:

--- a/themes/253a3a74-0cc4-47b7-8b82-996a64f030d5/theme.json
+++ b/themes/253a3a74-0cc4-47b7-8b82-996a64f030d5/theme.json
@@ -7,5 +7,7 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/253a3a74-0cc4-47b7-8b82-996a64f030d5/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/253a3a74-0cc4-47b7-8b82-996a64f030d5/image.png",
     "author": "ahmaadaziz",
+    "createdAt": "2024-10-12",
+    "updatedAt": "2024-10-12",
     "version": "1.0.0"
 }

--- a/themes/4596d8f9-f0b7-4aeb-aa92-851222dc1888/theme.json
+++ b/themes/4596d8f9-f0b7-4aeb-aa92-851222dc1888/theme.json
@@ -8,5 +8,7 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4596d8f9-f0b7-4aeb-aa92-851222dc1888/image.png",
     "author": "p-sw",
     "version": "1.0.0",
+    "tags": [],
+    "createdAt": "2024-10-12",
     "updatedAt": "2024-10-12"
 }

--- a/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/theme.json
+++ b/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/theme.json
@@ -10,5 +10,5 @@
     "version": "1.0.2",
     "tags": [],
     "createdAt": "2024-09-01",
-    "updatedAt": "2024-09-07"
+    "updatedAt": "2024-10-12"
 }

--- a/themes/5c4d7772-d963-4672-ab03-e9d541438881/theme.json
+++ b/themes/5c4d7772-d963-4672-ab03-e9d541438881/theme.json
@@ -8,5 +8,7 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/5c4d7772-d963-4672-ab03-e9d541438881/image.png",
     "author": "jvabn",
     "version": "1.0.0",
+    "tags": [],
+    "createdAt": "2024-10-12",
     "updatedAt": "2024-10-12"
 }

--- a/themes/5ca67725-1f43-4ff2-9fcf-0c59af71c73a/theme.json
+++ b/themes/5ca67725-1f43-4ff2-9fcf-0c59af71c73a/theme.json
@@ -15,5 +15,5 @@
         "dark"
     ],
     "createdAt": "2024-08-31",
-    "updatedAt": ""
+    "updatedAt": "2024-08-31"
 }

--- a/themes/664c54f9-d97d-410b-a479-23dd8a08a628/theme.json
+++ b/themes/664c54f9-d97d-410b-a479-23dd8a08a628/theme.json
@@ -9,5 +9,7 @@
     "author": "TheRealMG",
     "version": "1.0.0",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/664c54f9-d97d-410b-a479-23dd8a08a628/preferences.json",
+    "tags": [],
+    "createdAt": "2024-10-12",
     "updatedAt": "2024-10-12"
 }

--- a/themes/753c7518-237d-480a-abfd-1f42a7eabacc/theme.json
+++ b/themes/753c7518-237d-480a-abfd-1f42a7eabacc/theme.json
@@ -10,5 +10,5 @@
     "version": "1.0.2",
     "tags": [],
     "createdAt": "2024-09-24",
-    "updatedAt": "2024-09-25"
+    "updatedAt": "2024-10-12"
 }

--- a/themes/7ba20fe1-7286-4b1f-9bf6-39d40bec8ae0/theme.json
+++ b/themes/7ba20fe1-7286-4b1f-9bf6-39d40bec8ae0/theme.json
@@ -8,5 +8,7 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/7ba20fe1-7286-4b1f-9bf6-39d40bec8ae0/image.png",
     "author": "shaeriz",
     "version": "1.0.0",
+    "tags": [],
+    "createdAt": "2024-10-12",
     "updatedAt": "2024-10-12"
 }

--- a/themes/bb61b145-6875-4afe-86f2-ab00024459dc/theme.json
+++ b/themes/bb61b145-6875-4afe-86f2-ab00024459dc/theme.json
@@ -8,5 +8,7 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/bb61b145-6875-4afe-86f2-ab00024459dc/image.png",
     "author": "mehalter",
     "version": "1.0.0",
+    "tags": [],
+    "createdAt": "2024-10-12",
     "updatedAt": "2024-10-12"
 }

--- a/themes/f7c71d9a-bce2-420f-ae44-a64bd92975ab/theme.json
+++ b/themes/f7c71d9a-bce2-420f-ae44-a64bd92975ab/theme.json
@@ -1,1 +1,14 @@
-{"id": "f7c71d9a-bce2-420f-ae44-a64bd92975ab", "name": "Better Unloaded Tabs", "description": "Makes unloaded tabs easier to notice by making them greyscale and transparent.", "homepage": "https://github.com/Felkazz/zen-browser-better-unloaded-tabs", "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/f7c71d9a-bce2-420f-ae44-a64bd92975ab/chrome.css", "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/f7c71d9a-bce2-420f-ae44-a64bd92975ab/readme.md", "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/f7c71d9a-bce2-420f-ae44-a64bd92975ab/image.png", "author": "Felkazz", "version": "1.0.1", "updatedAt": "2024-10-12"}
+{
+  "id": "f7c71d9a-bce2-420f-ae44-a64bd92975ab",
+  "name": "Better Unloaded Tabs",
+  "description": "Makes unloaded tabs easier to notice by making them greyscale and transparent.",
+  "homepage": "https://github.com/Felkazz/zen-browser-better-unloaded-tabs",
+  "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/f7c71d9a-bce2-420f-ae44-a64bd92975ab/chrome.css",
+  "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/f7c71d9a-bce2-420f-ae44-a64bd92975ab/readme.md",
+  "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/f7c71d9a-bce2-420f-ae44-a64bd92975ab/image.png",
+  "author": "Felkazz",
+  "version": "1.0.1",
+  "tags": [],
+  "createdAt": "2024-10-12",
+  "updatedAt": "2024-10-12"
+}


### PR DESCRIPTION
- Fixed an issue where tags could be added multiple times when rebuilding themes.
- Fixed an issue where `createdAt` property was not being added for pull requests created prior to introduction of new properties.
- Fixed an issue where `tags` property was not being added for pull requests created prior to introduction of new properties.
- Updated the affected `theme.json` files for themes merged today.
- Fixed an issue where the action fails if another commit is made before action finishes
- Made the action only initiate when changes are detected in the `themes/` subdirectory

After merging, please manually run the `Submit PR` action so that `themes.json` can be rebuilt