### PR TITLE
Update Theme: Super Url Bar

### DIFF
--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/chrome.css
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/chrome.css
@@ -41,11 +41,11 @@
 
 @media (-moz-bool-pref: "uc.urlbar.move-icon-into") {
   #page-action-buttons {
-    margin-right: calc(var(--urlbar-min-height) - 2px - 4 * var(--urlbar-container-padding)) !important;
+    margin-right: calc(var(--urlbar-min-height) - 1px - 4 * var(--urlbar-container-padding)) !important;
   }
   
   #urlbar-container+.chromeclass-toolbar-additional {
-    margin-inline-start: calc(0px - 19px - 2 * var(--urlbar-icon-padding) - var(--urlbar-margin-inline)) !important;
+    margin-inline-start: calc(-21px - 2 * var(--urlbar-icon-padding) - var(--urlbar-margin-inline)) !important;
     position: relative;
     --toolbarbutton-inner-padding: var(--urlbar-icon-padding);
     --toolbarbutton-hover-background: color-mix(in srgb, var(--uc-urlbar-custom-bg-color) 90%, light-dark(black, white)) !important;
@@ -96,11 +96,17 @@
 }
 
 /* Custom Colors for Url Bar */
-@media (-moz-bool-pref: "uc.urlbar.custom-bg-color.checkbox") {
-  :root {
-    --zen-urlbar-background: var(--uc-urlbar-custom-bg-color) !important;
-    --zen-colors-input-bg: var(--uc-urlbar-custom-bg-color) !important;
-  }
+:root:has(#theme-Super-Url-Bar[uc-urlbar-custom-bg-color-enabled="Normal"]) {
+  --zen-colors-input-bg: var(--uc-urlbar-custom-bg-color) !important;
+}
+
+:root:has(#theme-Super-Url-Bar[uc-urlbar-custom-bg-color-enabled="Advanced"]) {
+  --zen-urlbar-background: var(--uc-urlbar-custom-bg-color) !important;
+  --zen-colors-input-bg: var(--uc-urlbar-custom-bg-color) !important;
+}
+
+:root:has(#theme-Super-Url-Bar[uc-urlbar-custom-bg-color-enabled="Normal"],
+          #theme-Super-Url-Bar[uc-urlbar-custom-bg-color-enabled="Advanced"]) {
   #identity-icon-box, #identity-permission-box {
     background-color: color-mix(in srgb, var(--uc-urlbar-custom-bg-color) 90%, light-dark(black, white)) !important;
   }
@@ -160,6 +166,18 @@
       opacity: 1;
     } 
   }
+  @media (-moz-bool-pref: "uc.urlbar.icon.container.removed") {
+    #urlbar:hover #userContext-icons {
+      position: relative;
+      opacity: 1;
+    } 
+  }
+  @media (-moz-bool-pref: "uc.urlbar.icon.left-side.removed") {
+    #urlbar:hover #identity-box {
+      position: relative;
+      opacity: 1;
+    } 
+  }
 }
 
 /* Removes certain buttons from the url bar (when toggled) */
@@ -193,6 +211,20 @@
 }
 @media (-moz-bool-pref: "uc.urlbar.icon.pip.removed") {
   #picture-in-picture-button {
+    opacity: 0;
+    position: var(--position-var);
+    transition: 100ms linear, opacity 200ms linear;
+  }
+}
+@media (-moz-bool-pref: "uc.urlbar.icon.container.removed") {
+  #userContext-icons {
+    opacity: 0;
+    position: var(--position-var);
+    transition: 100ms linear, opacity 200ms linear;
+  }
+}
+@media (-moz-bool-pref: "uc.urlbar.icon.left-side.removed") {
+  #identity-box {
     opacity: 0;
     position: var(--position-var);
     transition: 100ms linear, opacity 200ms linear;

--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/preferences.json
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/preferences.json
@@ -63,9 +63,26 @@
         ]
     },
     {
-        "property": "uc.urlbar.custom-bg-color.checkbox",
-        "label": "Enable Custom Colors for the Url Bar",
+        "property": "browser.urlbar.openintab",
+        "label": "Always open websites in a new tab when using url bar",
         "type": "checkbox"
+    },
+    {
+        "property": "uc.urlbar.custom-bg-color.enabled",
+        "label": "Enables Custom Colors for the Url Bar",
+        "type": "dropdown",
+        "placeholder": "Disabled",
+        "disabledOn": [],
+        "options": [
+            {
+                "label": "Only color url bar when not in focus",
+                "value": "Normal"
+            },
+            {
+                "label": "Always color url bar (not focused + focused)",
+                "value": "Advanced"
+            }
+        ]
     },
     {
         "property": "uc.urlbar.custom-bg-color",
@@ -100,6 +117,18 @@
     {
         "property": "uc.urlbar.icon.pip.removed",
         "label": "Hides the Picture-in-Picture icon",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.urlbar.icon.container.removed",
+        "label": "Hides the Container Tab icon and text",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.urlbar.icon.left-side.removed",
+        "label": "Hides all the icons/buttons on the left side",
         "type": "checkbox",
         "disabledOn": []
     },

--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/readme.md
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/readme.md
@@ -4,8 +4,9 @@
   - Adjust border radius of the url bar (Circle like corners)
   - Center url text
   - Remove the border of the url bar
-  - Move 1 button that's directly next to the url bar (you can do that by using 'Customize Toolbar') into the url bar (Credit: YouCanTouCan)
+  - Move 1 button that's directly next to the url bar (you can do that by using 'Customize Toolbar') into the url bar (Credit: [YouCanTouCan](https://github.com/YouCanTouCan))
   - Blur the background when the url bar is in focus (5 Levels of Intensity)
+  - Always open Websites in a New Tab from Url Bar
   - Custom Colors for your url bar
   - Hide icons inside the url bar:
     - Zoom icon
@@ -13,4 +14,6 @@
     - Bookmark (Star) icon
     - Reader-Mode icon
     - PiP icon
+    - Container Tab icon and text
+    - Left side icons
   - Show hidden icons when hovering the url bar

--- a/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/theme.json
+++ b/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/theme.json
@@ -7,9 +7,11 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/image.png",
     "author": "JLBlk",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d93e67f8-e5e1-401e-9b82-f9d5bab231e6/preferences.json",
-    "tags": [],
+    "tags": [
+        "urlbar"
+    ],
     "createdAt": "2024-08-31",
     "updatedAt": "2024-10-06"
 }


### PR DESCRIPTION
- Added option to always open websites in new tabs from url bar (closes https://github.com/JLBlk/Zen-Themes/issues/32)
- Added option to hide container tab label in url bar
- Added option to hide left side icons in url bar
- Changed custom colors chechbox to dropdown with option to only color url bar when not in focus
- Refined margins for "Move 1 button into url bar" option (closes https://github.com/JLBlk/Zen-Themes/issues/27)
- Added "urlbar" tag to json
- Increased Version to 1.4.0