### PR TITLE
fix(float-compact-sidebar): Fix hover zone when collapsed.

### DIFF
--- a/themes/46690a54-5eff-4141-8af8-9cd772ab6e2c/chrome.css
+++ b/themes/46690a54-5eff-4141-8af8-9cd772ab6e2c/chrome.css
@@ -1,61 +1,59 @@
-@-moz-document url-prefix("chrome:") {
-    @media (-moz-bool-pref: "zen.view.compact") {
-        :root:not([customizing]) {
-            --separation: calc(var(--zen-element-separation) + 1px);
+@media (-moz-bool-pref: "zen.view.compact") {
+    :root:not([customizing]) {
+        --separation: calc(var(--zen-element-separation) + 1px);
 
-            --margin: 7px;
+        --margin: 7px;
 
-            --horiz-padding: 10px;
-            --vert-padding: 5px;
+        --horiz-padding: 10px;
+        --vert-padding: 5px;
 
-            @media (-moz-bool-pref: "zen.view.compact.hide-tabbar") {
-                & #navigator-toolbox{
-                  position: absolute !important;
-                  left: 0 !important;
-                  padding-right: var(--horiz-padding) !important;
-                  padding-left: calc(var(--margin) + calc(var(--separation) + var(--horiz-padding))) !important;
-                  padding-top: calc(var(--vert-padding) + var(--margin)) !important;
-                  padding-bottom: calc(var(--vert-padding) + var(--margin)) !important;
-                  top: var(--separation) !important;
-                  bottom: var(--separation) !important;
-                  height: auto !important;
-                  border: none !important;
-                  box-shadow: none !important;
+        @media (-moz-bool-pref: "zen.view.compact.hide-tabbar") {
+            & #navigator-toolbox{
+              position: absolute !important;
+              left: 0 !important;
+              padding-right: var(--horiz-padding) !important;
+              padding-left: calc(var(--margin) + calc(var(--separation) + var(--horiz-padding))) !important;
+              padding-top: calc(var(--vert-padding) + var(--margin)) !important;
+              padding-bottom: calc(var(--vert-padding) + var(--margin)) !important;
+              top: var(--separation) !important;
+              bottom: var(--separation) !important;
+              height: auto !important;
+              border: none !important;
+              box-shadow: none !important;
 
-                  background: none !important;
-                  min-width: calc(calc(calc(var(--horiz-padding) * 2) + var(--zen-toolbox-max-width)) + var(--margin)) !important;
+              background: none !important;
+              min-width: calc(calc(calc(var(--horiz-padding) * 2) + var(--zen-toolbox-max-width)) + var(--margin)) !important;
 
-                  transform: translate3d(calc(-100% - 10px), 0, 0) !important;
-                }
+              transform: translate3d(calc(-100% - 10px), 0, 0) !important;
+            }
 
-                & #titlebar {
-                  border: none !important;
-                  padding: 0 !important;
-                  box-shadow: none !important;
-                  background: none !important;
-                }
+            & #titlebar {
+              border: none !important;
+              padding: 0 !important;
+              box-shadow: none !important;
+              background: none !important;
+            }
 
-                & #navigator-toolbox[zen-expanded]{
-                    min-width: 250px !important;
-                }
+            & #navigator-toolbox[zen-expanded]{
+                min-width: 250px !important;
+            }
 
-                & #navigator-toolbox::before{
-                    content: "" !important;
-                    position: absolute !important;
-                    top: var(--margin) !important;
-                    bottom: var(--margin) !important;
-                    left: calc(var(--separation) + var(--margin)) !important;
-                    right: 0 !important;
+            & #navigator-toolbox::before{
+                content: "" !important;
+                position: absolute !important;
+                top: var(--margin) !important;
+                bottom: var(--margin) !important;
+                left: calc(var(--separation) + var(--margin)) !important;
+                right: 0 !important;
 
-                    background: var(--zen-themed-toolbar-bg) !important;
-                    border-radius: var(--zen-border-radius) !important;
-                    box-shadow: 15px -10px 20px -20px black !important;
-                    border: none;
-                }
+                background: var(--zen-themed-toolbar-bg) !important;
+                border-radius: var(--zen-border-radius) !important;
+                box-shadow: 15px -10px 20px -20px black !important;
+                border: none;
+            }
 
-                & #navigator-toolbox:hover, & #navigator-toolbox[zen-has-hover], & #navigator-toolbox:focus-within, & #navigator-toolbox[zen-user-show], & #navigator-toolbox[flash-popup], & #navigator-toolbox[has-popup-menu], & #navigator-toolbox[movingtab], & #mainPopupSet:has(> #appMenu-popup:hover) ~ toolbox, & #navigator-toolbox:has(.tabbrowser-tab:active), & #navigator-toolbox:has([open="true"]:not(tab):not(#zen-sidepanel-button)) {
-                    transform: translate3d(0, 0, 0) !important;
-                }
+            & #navigator-toolbox:hover, & #navigator-toolbox[zen-has-hover], & #navigator-toolbox:focus-within, & #navigator-toolbox[zen-user-show], & #navigator-toolbox[flash-popup], & #navigator-toolbox[has-popup-menu], & #navigator-toolbox[movingtab], & #mainPopupSet:has(> #appMenu-popup:hover) ~ toolbox, & #navigator-toolbox:has(.tabbrowser-tab:active), & #navigator-toolbox:has([open="true"]:not(tab):not(#zen-sidepanel-button)) {
+                transform: translate3d(0, 0, 0) !important;
             }
         }
     }

--- a/themes/46690a54-5eff-4141-8af8-9cd772ab6e2c/chrome.css
+++ b/themes/46690a54-5eff-4141-8af8-9cd772ab6e2c/chrome.css
@@ -1,54 +1,61 @@
+@-moz-document url-prefix("chrome:") {
+    @media (-moz-bool-pref: "zen.view.compact") {
+        :root:not([customizing]) {
+            --separation: calc(var(--zen-element-separation) + 1px);
 
-@media (-moz-bool-pref: "zen.view.compact") {
-    :root:not([customizing]) {
-        --separation: calc(var(--zen-element-separation) + 1px);
-        
-        --margin: 7px;
-        
-        --horiz-padding: 10px;
-        --vert-padding: 5px;
-        @media (-moz-bool-pref: "zen.view.compact.hide-tabbar") {
-            & #navigator-toolbox{
-                position: absolute !important;
-                left: 0 !important;
-                padding-right: var(--horiz-padding) !important;
-                padding-left: calc(var(--margin) + calc(var(--separation) + var(--horiz-padding))) !important;
-                padding-top: calc(var(--vert-padding) + var(--margin)) !important;
-                padding-bottom: calc(var(--vert-padding) + var(--margin)) !important;
-                top: 1px !important;
-                bottom: var(--separation) !important;
-                height: auto !important;
-                border: none !important;
-                box-shadow: none !important;
+            --margin: 7px;
 
-background: none !important;
-                min-width: calc(calc(calc(var(--horiz-padding) * 2) + var(--zen-toolbox-max-width)) + var(--margin)) !important;
-                
-                transform: translate3d(-90%, 0, 0) !important;
-            }
-            
-            & #navigator-toolbox[zen-expanded]{
-                min-width: 250px !important;                
-            }
-            
-            & #navigator-toolbox::before{
-                content: "" !important;
-                position: absolute !important;
-                top: var(--margin) !important;
-                bottom: var(--margin) !important;
-                left: calc(var(--separation) + var(--margin)) !important;
-                right: 0 !important;
-                
-                background: var(--zen-themed-toolbar-bg) !important;
-                border-radius: var(--zen-border-radius) !important;
-                box-shadow: 15px -10px 20px -20px black !important;
-                border: none;
-               
-                
-            }
-            
-               & #navigator-toolbox:hover, & #navigator-toolbox[zen-has-hover], & #navigator-toolbox:focus-within, & #navigator-toolbox[zen-user-show], & #navigator-toolbox[flash-popup], & #navigator-toolbox[has-popup-menu], & #navigator-toolbox[movingtab], & #mainPopupSet:has(> #appMenu-popup:hover) ~ toolbox, & #navigator-toolbox:has(.tabbrowser-tab:active), & #navigator-toolbox:has([open="true"]:not(tab):not(#zen-sidepanel-button)){
-                transform: translate3d(0, 0, 0) !important;
+            --horiz-padding: 10px;
+            --vert-padding: 5px;
+
+            @media (-moz-bool-pref: "zen.view.compact.hide-tabbar") {
+                & #navigator-toolbox{
+                  position: absolute !important;
+                  left: 0 !important;
+                  padding-right: var(--horiz-padding) !important;
+                  padding-left: calc(var(--margin) + calc(var(--separation) + var(--horiz-padding))) !important;
+                  padding-top: calc(var(--vert-padding) + var(--margin)) !important;
+                  padding-bottom: calc(var(--vert-padding) + var(--margin)) !important;
+                  top: var(--separation) !important;
+                  bottom: var(--separation) !important;
+                  height: auto !important;
+                  border: none !important;
+                  box-shadow: none !important;
+
+                  background: none !important;
+                  min-width: calc(calc(calc(var(--horiz-padding) * 2) + var(--zen-toolbox-max-width)) + var(--margin)) !important;
+
+                  transform: translate3d(calc(-100% - 10px), 0, 0) !important;
+                }
+
+                & #titlebar {
+                  border: none !important;
+                  padding: 0 !important;
+                  box-shadow: none !important;
+                  background: none !important;
+                }
+
+                & #navigator-toolbox[zen-expanded]{
+                    min-width: 250px !important;
+                }
+
+                & #navigator-toolbox::before{
+                    content: "" !important;
+                    position: absolute !important;
+                    top: var(--margin) !important;
+                    bottom: var(--margin) !important;
+                    left: calc(var(--separation) + var(--margin)) !important;
+                    right: 0 !important;
+
+                    background: var(--zen-themed-toolbar-bg) !important;
+                    border-radius: var(--zen-border-radius) !important;
+                    box-shadow: 15px -10px 20px -20px black !important;
+                    border: none;
+                }
+
+                & #navigator-toolbox:hover, & #navigator-toolbox[zen-has-hover], & #navigator-toolbox:focus-within, & #navigator-toolbox[zen-user-show], & #navigator-toolbox[flash-popup], & #navigator-toolbox[has-popup-menu], & #navigator-toolbox[movingtab], & #mainPopupSet:has(> #appMenu-popup:hover) ~ toolbox, & #navigator-toolbox:has(.tabbrowser-tab:active), & #navigator-toolbox:has([open="true"]:not(tab):not(#zen-sidepanel-button)) {
+                    transform: translate3d(0, 0, 0) !important;
+                }
             }
         }
     }


### PR DESCRIPTION
I originally made an issue for is (#520), following the instructions of [this page](https://docs.zen-browser.app/themes-store/themes-marketplace-submission-guidelines). Now I'm making this PR at the request of @KiKaraage.

**Quick recap:**

The change is quite simple, it's about the hover zone for the sidebar when hidden. It's too large and sometimes interferes with the UI elements of webpages, making them unreachable.

I also fixed a minor inconsistency in top separation not being equal to the bottom one.

**Later, after a zen update changed the sidebar, I also made this update:**

The new sidebar/toolbox added a padding and border on the `#titlebar` element, which really doesn't work with the floating style. So I've also removed this.