### PR TITLE
Bookmarks toolbar visibility fix

### DIFF
--- a/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/chrome.css
+++ b/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/chrome.css
@@ -37,7 +37,25 @@
     #PersonalToolbar:not([customizing]) {
        background-color: var(--zen-colors-tertiary) !important;
     }
-}  
+}
+
+@media (-moz-bool-pref: "uc.bookmarks.transparent") {
+    #personal-bookmarks toolbarbutton.bookmark-item {
+        background-color: var(--zen-colors-tertiary) !important;
+    }
+
+    #personal-bookmarks #PlacesToolbarItems>toolbarbutton.bookmark-item:not(.subviewbutton, [disabled="true"], [open]):hover {
+        filter: brightness(1.5)
+    }
+
+    #personal-bookmarks #PlacesToolbarItems>toolbarbutton.bookmark-item:not(.subviewbutton, [disabled="true"]):hover:active {
+        filter: brightness(3)
+    }
+
+    #personal-bookmarks #PlacesToolbarItems>toolbarbutton.bookmark-item[open="true"] {
+        filter: brightness(3)
+    }
+}
 
 @media (-moz-bool-pref: "uc.bookmarks.expand-on-search") or (-moz-bool-pref: "uc.bookmarks.expand-on-hover") {
     #PersonalToolbar[collapsed="false"]:not([customizing]) {

--- a/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/theme.json
+++ b/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/theme.json
@@ -8,7 +8,7 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/image.png",
     "author": "n7itro",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/preferences.json",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "tags": [],
     "createdAt": "2024-08-19",
     "updatedAt": "2024-10-26"


### PR DESCRIPTION
Adds small rectangles to improve visibility on lighter background. There is a small overlap with top border which I wasn't able to fix without reducing top margin which caused [spacing issue](https://github.com/n7itro/Zen-Themes/issues/19). Fix was adapted from Firefox Mod Blur transparent bookmark bar mod.

![image](https://github.com/user-attachments/assets/d0af2b30-e781-4517-90d5-cfd764c36dbc)

![image](https://github.com/user-attachments/assets/643f0304-4dbf-40a5-b423-b1621882e62d)


