### PR TITLE
Update PywalZen

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -36,7 +36,7 @@
         "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/readme.md",
         "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/image.png",
         "author": "Axenide",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/preferences.json",
         "tags": [],
         "createdAt": "2024-09-29",

--- a/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/chrome.css
+++ b/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/chrome.css
@@ -1,4 +1,5 @@
 :root {
+  --zen-primary-color: #d9d9d9 !important;
   --zen-colors-primary: var(--tab-loading-fill) !important;
   --zen-colors-secondary: var(--tab-loading-fill) !important;
   --toolbarbutton-icon-fill: var(--tab-loading-fill) !important;
@@ -6,22 +7,32 @@
 
 :root:has(#theme-PywalZen[uc-pywalzen-darkness="default"]) {
   --zen-colors-tertiary: var(--lwt-accent-color) !important;
+  --zen-main-browser-background: var(--lwt-accent-color) !important;
+  --zen-themed-toolbar-bg: var(--lwt-accent-color) !important;
 }
 
 :root:has(#theme-PywalZen[uc-pywalzen-darkness="dark"]) {
   --zen-colors-tertiary: color-mix(in srgb, var(--lwt-accent-color), black 25%) !important;
+  --zen-main-browser-background: color-mix(in srgb, var(--lwt-accent-color), black 25%) !important;
+  --zen-themed-toolbar-bg: color-mix(in srgb, var(--lwt-accent-color), black 25%) !important;
 }
 
 :root:has(#theme-PywalZen[uc-pywalzen-darkness="darker"]) {
   --zen-colors-tertiary: color-mix(in srgb, var(--lwt-accent-color), black 50%) !important;
+  --zen-main-browser-background: color-mix(in srgb, var(--lwt-accent-color), black 50%) !important;
+  --zen-themed-toolbar-bg: color-mix(in srgb, var(--lwt-accent-color), black 50%) !important;
 }
 
 :root:has(#theme-PywalZen[uc-pywalzen-darkness="yet-darker"]) {
   --zen-colors-tertiary: color-mix(in srgb, var(--lwt-accent-color), black 75%) !important;
+  --zen-main-browser-background: color-mix(in srgb, var(--lwt-accent-color), black 75%) !important;
+  --zen-themed-toolbar-bg: color-mix(in srgb, var(--lwt-accent-color), black 75%) !important;
 }
 
 :root:has(#theme-PywalZen[uc-pywalzen-darkness="pitch-black"]) {
   --zen-colors-tertiary: black !important;
+  --zen-main-browser-background: black !important;
+  --zen-themed-toolbar-bg: black !important;
 }
 
 #urlbar:not([focused="true"]):not([breakout-extend="true"]) > #urlbar-background {

--- a/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/readme.md
+++ b/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/readme.md
@@ -2,7 +2,7 @@
 
 By using some native color variables, this theme makes [Pywalfox](https://github.com/Frewacom/pywalfox) work with [Zen](https://zen-browser.app/) Browser correctly.
 
-> **NOTE**: Zen Browser implemented custom gradients for each workspace. While this theme works, you need to tweak the contrast for Zen to recognize it, just the first time. It is compatible with gradients and the new grain effect!
+> **NOTE**: This theme overrides custom gradients, but it is compatible with the new grain effect!
 
 ![](https://raw.githubusercontent.com/Axenide/PywalZen/main/screenshots/1.png)
 ![](https://raw.githubusercontent.com/Axenide/PywalZen/main/screenshots/2.png)

--- a/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/theme.json
+++ b/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/theme.json
@@ -7,7 +7,7 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/image.png",
     "author": "Axenide",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/d2953516-d239-4ef8-aac5-b238e3dc0360/preferences.json",
     "tags": [],
     "createdAt": "2024-09-29",


### PR DESCRIPTION
Hi, I had to make some modifications:
- **Override custom gradients:** The user had to tweak their gradients on every new session, sometimes even on new windows, which is an inconsistent  and annoying behavior. Overriding the `--zen-main-browser-background` variable solves this.
- **Hardcode `--zen-primary-color` to #d9d9d9:** This is due to inconsistencies between Pywal generated themes and the default colors of Zen. I tried several times to make it follow Pywal colors but I can't set a variable as its value, so I have chosen #d9d9d9 to be the color for this case, since it is neutral.