### PR TITLE
Update Mod: SuperPins

### DIFF
--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
@@ -1,4 +1,5 @@
 @media (-moz-bool-pref: "zen.tabs.vertical") {
+    
     /* Makes essentials transparent (when toggled) */
     :root:has(#theme-SuperPins[uc-essentials-color-scheme="transparent"]) {
         .tabbrowser-tab[zen-essential="true"]:not(:hover):not([selected="true"]) .tab-stack .tab-background {
@@ -182,6 +183,21 @@
                     visibility: hidden !important;
                 }
             }
+        }
+    }
+
+    /* Let pinned tabs have the same selected styling as essentials */ 
+    @media (-moz-bool-pref: "uc.pins.essentials-layout") {
+        #vertical-pinned-tabs-container {
+            grid-template-columns: repeat(auto-fit, minmax(var(--essentials-width), auto)) !important;
+            gap: var(--essentials-gap) var(--essentials-gap) !important;
+        }
+    }
+
+    /* Hide reset button on pinned tabs */
+    @media (-moz-bool-pref: "uc.pins.hide-reset-button") {
+        #vertical-pinned-tabs-container .tab-reset-button {
+            display: none !important;
         }
     }
 }

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
@@ -22,18 +22,6 @@
         ]
     },
     {
-        "property": "uc.pins.legacy-layout",
-        "label": "Makes pinned tabs look similar to Essentials (icon only in a grid)",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
-        "property": "uc.pins.bg",
-        "label": "Adds a background to the pinned tabs",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
         "property": "uc.essentials.gap",
         "label": "Select the gap between Essentials",
         "type": "dropdown",
@@ -52,6 +40,25 @@
             {
                 "label": "Big",
                 "value": "Big"
+            }
+        ]
+    },
+    {
+        "property": "uc.pins.essentials-layout",
+        "label": "Adds selected width and gap styles from Essentials to pinned tabs as well",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.essentials.color-scheme",
+        "label": "Background/Color types of Essentials",
+        "type": "dropdown",
+        "placeholder": "Zen Default",
+        "disabledOn": [],
+        "options": [
+            {
+                "label": "Transparent Background",
+                "value": "transparent"
             }
         ]
     },
@@ -83,6 +90,24 @@
         ]
     },
     {
+        "property": "uc.pins.legacy-layout",
+        "label": "Makes pinned tabs look similar to Essentials (icon only in a grid)",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.pins.bg",
+        "label": "Adds a background to the pinned tabs",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "uc.pins.hide-reset-button",
+        "label": "Hide the reset button on pinned tabs",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
         "property": "uc.pins.only-show-active",
         "label": "Only shows loaded pinned tabs (when the tab bar is collapsed)",
         "type": "dropdown",
@@ -100,17 +125,10 @@
         ]
     },
     {
-        "property": "uc.essentials.color-scheme",
-        "label": "Background/Color types of Essentials",
-        "type": "dropdown",
-        "placeholder": "Zen Default",
-        "disabledOn": [],
-        "options": [
-            {
-                "label": "Transparent Background",
-                "value": "transparent"
-            }
-        ]
+        "property": "zen.workspaces.show-workspace-indicator",
+        "label": "Shows the workspace-indicator between Essentials and Pins",
+        "type": "checkbox",
+        "disabledOn": []
     },
     {
         "property": "browser.sessionstore.restore_pinned_tabs_on_demand",

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md
@@ -3,13 +3,14 @@
 This **Zen Mod** elevates your experience with pinned tabs and Essentials by making some UI/UX changes.
 
 ## Features (toggle in Zens Mod settings):
-  - Increase the width of Essentials (This can be controlled through a dropdown)
+  - Increase the width of Essentials/Pins (This can be controlled through a dropdown)
+  - Controllable Margins between Essentials/Pins (3 Options Dropdown)
   - Grid Layout for pinned tabs (Similar to Essentials, icon only)
   - Subtle Background for pinned tabs
   - Border around pinned tabs and/or Essentials
-  - Controllable Margins between Essentials (3 Options Dropdown)
   - Box like corners for Essentials (less rounded corners)
   - Hide unloaded pinned tabs when tab bar is collapsed (Additional option: Show all pinned tabs on hover even with tab bar collapsed)
   - Make Essentials transparent
+  - Hide the workspace indicator between Essentials and Pins
   - Load pinned tabs only when using them, instead of loading all of them on startup
   - Dim unloaded tabs

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
@@ -7,7 +7,7 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/image.png",
     "author": "JLBlk",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json",
     "tags": [
         "tabs"


### PR DESCRIPTION
- Adds option to apply Essentials width/gap setting to pins as well  (Thanks to @orbi-tal)
- Adds option to hide reset button on pinned tabs (https://github.com/JLBlk/Zen-Themes/issues/66) thanks to @limonkufu
- Adds option to hide workspace indicator between essentials and pins
- Increased Version to 1.4.2