### PR TITLE
Update theme: No Gaps

### DIFF
--- a/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/chrome.css
+++ b/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/chrome.css
@@ -3,26 +3,176 @@ and (-moz-bool-pref: "theme.no_gaps.fixes.center_split_view") {
 
   #zen-appcontent-wrapper:has(
   > #zen-tabbox-wrapper > #tabbrowser-tabbox
-  > #tabbrowser-tabpanels[zen-split-view="true"]){
+  > #tabbrowser-tabpanels[zen-split-view="true"]) 
+  > #zen-tabbox-wrapper{
 
-    margin-top: 1px;
-
-    & > #zen-tabbox-wrapper {
-      margin-bottom: 5px !important;
-      margin-right: 7px !important;
-    }
-
+    margin-top: 1px !important;
+    margin-bottom: 5px !important;
+    margin-right: 7px !important;
+    
     @media (-moz-bool-pref: "zen.view.compact"){
       @media (-moz-bool-pref: "zen.view.compact.hide-toolbar") {
-        margin-top: 3px !important;
+        margin-top: -3px !important;
       }
       @media (-moz-bool-pref: "zen.view.compact.hide-tabbar") {
-        margin-left: 2px !important;
+        margin-left: -3px !important;
       }
     }
-
+    
   }
 }
+
+
+:root[zen-single-toolbar="true"]:not([customizing]) {
+  @media (-moz-bool-pref: "zen.view.hide-window-controls") {
+    
+    @media (-moz-bool-pref: "theme.no_gaps.single_toolbar.disable_navbar"){
+      
+      @media (-moz-bool-pref: "theme.no_gaps.split.single_toolbar.disable_navbar"){
+        #zen-appcontent-navbar-container{
+          display: none !important;
+        }
+      }
+      
+      @media not (-moz-bool-pref: "theme.no_gaps.split.single_toolbar.disable_navbar"){
+        #zen-appcontent-wrapper:has(
+        > #zen-tabbox-wrapper > #tabbrowser-tabbox
+        > #tabbrowser-tabpanels:not([zen-split-view="true"])) 
+        > #zen-appcontent-navbar-container {
+          display: none !important;
+        }
+
+        @media (-moz-bool-pref: "theme.no_gaps.split.single_toolbar.hide_navbar"){
+          #zen-appcontent-wrapper:has(
+          > #zen-tabbox-wrapper > #tabbrowser-tabbox
+          > #tabbrowser-tabpanels[zen-split-view="true"]) {
+            height: calc(100% + var(--zen-element-separation));
+            transition: height 0.2s ease;
+
+            & > #zen-tabbox-wrapper{
+              top: calc(-1 * var(--zen-element-separation));
+              z-index: -1 !important;
+              transition: top 0.2s ease;
+            }
+            
+            &:not(:has(> #zen-appcontent-navbar-container:not(
+            [zen-has-hover="true"], [has-popup-menu], :focus-within)))
+            > #zen-tabbox-wrapper{
+              top: 0;
+            }
+            
+          }
+        }
+        
+      }
+      
+    }
+    
+    @media not (-moz-bool-pref: "theme.no_gaps.single_toolbar.disable_navbar"){
+      
+      @media (-moz-bool-pref: "theme.no_gaps.split.single_toolbar.disable_navbar"){
+        
+        #zen-appcontent-wrapper:has(
+        > #zen-tabbox-wrapper > #tabbrowser-tabbox
+        > #tabbrowser-tabpanels[zen-split-view="true"]) 
+        > #zen-appcontent-navbar-container {
+          display: none !important;
+        }
+        
+        @media (-moz-bool-pref: "theme.no_gaps.single_toolbar.hide_navbar"){
+          #zen-appcontent-wrapper:has(
+          > #zen-tabbox-wrapper > #tabbrowser-tabbox
+          > #tabbrowser-tabpanels:not([zen-split-view="true"])) {
+            height: calc(100% + var(--zen-element-separation));
+            transition: height 0.2s ease;
+
+            & > #zen-tabbox-wrapper{
+              top: calc(-1 * var(--zen-element-separation));
+              z-index: -1 !important;
+              transition: top 0.2s ease;
+            }
+            
+            &:not(:has(> #zen-appcontent-navbar-container:not(
+            [zen-has-hover="true"], [has-popup-menu], :focus-within)))
+            > #zen-tabbox-wrapper{
+              top: 0;
+            }
+          }
+        }
+        
+      }
+      
+      @media not (-moz-bool-pref: "theme.no_gaps.split.single_toolbar.disable_navbar"){
+        
+        @media (-moz-bool-pref: "theme.no_gaps.single_toolbar.hide_navbar"){
+          @media (-moz-bool-pref: "theme.no_gaps.split.single_toolbar.hide_navbar"){
+            #zen-appcontent-wrapper{
+              height: calc(100% + var(--zen-element-separation));
+              transition: height 0.2s ease;
+              
+              & > #zen-tabbox-wrapper{
+                top: calc(-1 * var(--zen-element-separation));
+                z-index: -1 !important;
+                transition: top 0.2s ease;
+              }
+              
+              &:not(:has(> #zen-appcontent-navbar-container:not(
+              [zen-has-hover="true"], [has-popup-menu], :focus-within)))
+              > #zen-tabbox-wrapper{
+                top: 0;
+              }
+            }
+          }
+          @media not (-moz-bool-pref: "theme.no_gaps.split.single_toolbar.hide_navbar"){
+            #zen-appcontent-wrapper:has(
+            > #zen-tabbox-wrapper > #tabbrowser-tabbox
+            > #tabbrowser-tabpanels:not([zen-split-view="true"])) {
+              height: calc(100% + var(--zen-element-separation));
+              transition: height 0.2s ease;
+
+              & > #zen-tabbox-wrapper{
+                top: calc(-1 * var(--zen-element-separation));
+                z-index: -1 !important;
+                transition: top 0.2s ease;
+              }
+              
+              &:not(:has(> #zen-appcontent-navbar-container:not(
+              [zen-has-hover="true"], [has-popup-menu], :focus-within)))
+              > #zen-tabbox-wrapper{
+                top: 0;
+              }
+            }
+          }
+        }
+
+        @media not (-moz-bool-pref: "theme.no_gaps.single_toolbar.hide_navbar"){
+          @media (-moz-bool-pref: "theme.no_gaps.split.single_toolbar.hide_navbar"){
+            #zen-appcontent-wrapper:has(
+            > #zen-tabbox-wrapper > #tabbrowser-tabbox
+            > #tabbrowser-tabpanels[zen-split-view="true"]) {
+              height: calc(100% + var(--zen-element-separation));
+              transition: height 0.2s ease;
+
+              & > #zen-tabbox-wrapper{
+                top: calc(-1 * var(--zen-element-separation));
+                z-index: -1 !important;
+                transition: top 0.2s ease;
+              }
+              &:not(:has(> #zen-appcontent-navbar-container:not(
+              [zen-has-hover="true"], [has-popup-menu], :focus-within)))
+              > #zen-tabbox-wrapper{
+                top: 0;
+              }
+            }
+          }
+        }
+        
+      }
+    }
+    
+  }
+}
+
 
 @media not (-moz-bool-pref: "theme.no_gaps.split.outline") {
   hbox.browserSidebarContainer{
@@ -91,6 +241,15 @@ and (-moz-bool-pref: "theme.no_gaps.fixes.center_split_view") {
       --zen-split-row-gap: 0 !important;
       --zen-split-column-gap: 0 !important;
     }
+    
+    div.zen-split-view-splitter[orient="vertical"]{
+      margin-left: calc(-1 * var(--zen-element-separation) + 1px) !important;
+    }
+    
+    div.zen-split-view-splitter[orient="horizontal"]{
+      height: calc(var(--zen-element-separation) * 2 - 3px) !important;
+      margin-top: calc(-1 * var(--zen-element-separation) + 1px) !important;
+    }
 
     #zen-appcontent-wrapper {
       margin: 0 !important;
@@ -130,6 +289,15 @@ and (-moz-bool-pref: "theme.no_gaps.fixes.center_split_view") {
     tabbox#tabbrowser-tabbox{
       --zen-split-row-gap: 0 !important;
       --zen-split-column-gap: 0 !important;
+    }
+    
+    div.zen-split-view-splitter[orient="vertical"]{
+      margin-left: calc(-1 * var(--zen-element-separation) + 1px) !important;
+    }
+    
+    div.zen-split-view-splitter[orient="horizontal"]{
+      height: calc(var(--zen-element-separation) * 2 - 3px) !important;
+      margin-top: calc(-1 * var(--zen-element-separation) + 1px) !important;
     }
 
     @media (-moz-bool-pref: "theme.no_gaps.split.outline") {

--- a/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/preferences.json
+++ b/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/preferences.json
@@ -42,6 +42,30 @@
         "defaultValue": true
     },
     {
+        "property": "theme.no_gaps.single_toolbar.hide_navbar",
+        "label": "Hide top bar in single-tab view (single toolbar)",
+        "type": "checkbox",
+        "defaultValue": true
+    },
+    {
+        "property": "theme.no_gaps.split.single_toolbar.hide_navbar",
+        "label": "Hide top bar in multi-tab view (single toolbar)",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "theme.no_gaps.single_toolbar.disable_navbar",
+        "label": "Remove top bar in single-tab view (single toolbar)",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "theme.no_gaps.split.single_toolbar.disable_navbar",
+        "label": "Remove top bar in multi-tab view (single toolbar)",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
         "property": "theme.no_gaps.fixes.center_split_view",
         "label": "Fix: Make margin in different view modes consistent",
         "type": "checkbox",

--- a/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/readme.md
+++ b/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/readme.md
@@ -1,36 +1,64 @@
 # No Gaps  
-Removes gaps between a browser tab and browser window when the view isn't split.  
-Also implements miscellaneous fixes listed below.  
+#### Removes gaps between a browser tab and browser window when the view isn't split.  
+Full list of features below.  
   
 ## Options  
 - Gaps in single-tab view  
-Prevents the theme from removing **gaps** in **single-tab** view mode.  
+Prevents the theme from removing gaps.  
+Works in: Single-tab view  
 Default: Off  
   
 - Gaps in multi-tab view  
-Prevents the theme from removing **gaps** in **multi-tab** view mode.  
+Prevents the theme from removing gaps.  
+Works in: Multi-tab view  
 Default: On  
   
 - Rounded corners in single-tab view  
-Prevents the theme from removing **rounded corners** in **single-tab** view mode.  
+Prevents the theme from removing rounded corners.  
+Works in: Single-tab view  
 Default: Off  
   
 - Rounded corners in multi-tab view  
-Prevents the theme from removing **rounded corners** in **multi-tab** view mode.  
+Prevents the theme from removing rounded corners.  
+Works in: Multi-tab view  
 Default: On  
   
 - Shadow in single-tab view  
-Prevents the theme from removing **shadows around the tab** in **single-tab** view mode.  
+Prevents the theme from removing shadows around the tab.  
+Works in: Single-tab view  
 Default: On  
   
 - Shadow in multi-tab view  
-Prevents the theme from removing **shadows around the tab** in **single-tab** view mode.  
+Prevents the theme from removing shadows around the tabs.  
+Works in: Multi-tab view  
 Default: On  
   
 - Outline in multi-tab view  
-Prevents the theme from removing the **highlighted outline/border around** the **active tab** in **multi-tab** view mode  
+Prevents the theme from removing the highlighted outline/border around the active tab in multi-tab view.  
+Works in: Multi-tab view  
 Default: On  
   
+- Hide top bar in single-tab view (single toolbar)  
+Removes the gap caused by the top bar in single toolbar mode.  
+Works in: Single-tab view  
+Default: On  
+  
+- Hide top bar in multi-tab view (single toolbar)  
+Removes the gap caused by the top bar in single toolbar mode.  
+Works in: Multi-tab view  
+Default: Off  
+  
+- Remove top bar in single-tab view (single toolbar)  
+Stops the top bar from ever rendering in single toolbar mode.  
+Works in: Single-tab view  
+Default: Off  
+  
+- Remove top bar in multi-tab view (single toolbar)  
+Stops the top bar from ever rendering in single toolbar mode.  
+Works in: Multi-tab view  
+Default: Off  
+  
 - Fix: Make margin in different view modes consistent  
-Tries to make margin consistent no matter how many tabs you have open in the same view  
+Changes margin values in multi-tab view to make it consistent with single-tab view  
+Works in: Multi-tab view  
 Default: Off  

--- a/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/theme.json
+++ b/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/theme.json
@@ -7,7 +7,7 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/bfcc400a-4ecb-4752-bfd2-a68f116a2722/image.png",
     "author": "Peleret",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "tags": [],
     "createdAt": "2024-10-21",
     "updatedAt": "2024-12-18",


### PR DESCRIPTION
Adds 2 new options for each view mode (normal and split)
  + Hide top bar
    > Removes the gap caused by the top bar in single toolbar mode.
  + Remove top bar
    > Stops the top bar from ever rendering.

Fixes splitters in split view when gaps are disabled (the things used to resize tabs). Vertical ones were off-center and horizontal ones had a height of 0 so you couldn't even interact with them.

Updates readme to improve clarity