### PR TITLE
Update Theme: No Sidebar Scrollbar

### DIFF
--- a/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/chrome.css
+++ b/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/chrome.css
@@ -1,15 +1,15 @@
-@media not (-moz-bool-pref: "theme.nosidebarscrollbar.twilight") {
+@media not (-moz-bool-pref: "theme.nosidebarscrollbar.before173b") {
+  #zen-browser-tabs-wrapper {
+    scrollbar-width: none;
+  }
+}
+
+@media (-moz-bool-pref: "theme.nosidebarscrollbar.before173b") {
   scrollbox:nth-child(5) {
     scrollbar-width: none !important;
   }
   /* Pinned Tabs */
   #vertical-pinned-tabs-container {
     scrollbar-width: none !important;
-  }
-}
-
-@media (-moz-bool-pref: "theme.nosidebarscrollbar.twilight") {
-  #zen-browser-tabs-wrapper {
-    scrollbar-width: none;
   }
 }

--- a/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/chrome.css
+++ b/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/chrome.css
@@ -1,7 +1,15 @@
-scrollbox:nth-child(5) {
-  scrollbar-width: none !important;
+@media not (-moz-bool-pref: "theme.nosidebarscrollbar.twilight") {
+  scrollbox:nth-child(5) {
+    scrollbar-width: none !important;
+  }
+  /* Pinned Tabs */
+  #vertical-pinned-tabs-container {
+    scrollbar-width: none !important;
+  }
 }
-/* Pinned Tabs */
-#vertical-pinned-tabs-container {
-  scrollbar-width: none !important;
+
+@media (-moz-bool-pref: "theme.nosidebarscrollbar.twilight") {
+  #zen-browser-tabs-wrapper {
+    scrollbar-width: none;
+  }
 }

--- a/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/preferences.json
+++ b/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/preferences.json
@@ -1,8 +1,9 @@
 [
     {
-        "property": "theme.nosidebarscrollbar.twilight",
-        "label": "Enable if you are on twilight.",
+        "property": "theme.nosidebarscrollbar.before173b",
+        "label": "Enable if you are on version 1.7.2b or lower.",
         "type": "checkbox",
-        "disabledOn": []
+        "disabledOn": [],
+        "defaultValue": false
     }
 ]

--- a/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/preferences.json
+++ b/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/preferences.json
@@ -1,0 +1,8 @@
+[
+    {
+        "property": "theme.nosidebarscrollbar.twilight",
+        "label": "Enable if you are on twilight.",
+        "type": "checkbox",
+        "disabledOn": []
+    }
+]

--- a/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/theme.json
+++ b/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/theme.json
@@ -8,7 +8,7 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/image.png",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/preferences.json",
     "author": "mally8",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "tags": [
         "sidebar"
     ],

--- a/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/theme.json
+++ b/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/theme.json
@@ -6,9 +6,12 @@
     "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/chrome.css",
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/image.png",
+    "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4ab93b88-151c-451b-a1b7-a1e0e28fa7f8/preferences.json",
     "author": "mally8",
-    "version": "1.0.3",
-    "tags": [],
+    "version": "1.0.4",
+    "tags": [
+        "sidebar"
+    ],
     "createdAt": "2024-09-01",
     "updatedAt": "2025-01-26"
 }


### PR DESCRIPTION
Updated to work on Zen 1.7.3b tab bar changes (and 1.7.2t) with the option for 1.7.2b or older.