### PR TITLE
Disable browser.tabs.allow_transparent_browser by default

### DIFF
--- a/themes/39907934-59e9-4e42-89f0-a254d3c5e280/preferences.json
+++ b/themes/39907934-59e9-4e42-89f0-a254d3c5e280/preferences.json
@@ -26,7 +26,7 @@
         "property": "browser.tabs.allow_transparent_browser",
         "label": "Allow Transparent Browser Tabs",
         "type": "checkbox",
-        "defaultValue": true
+        "defaultValue": false
     },
     {
         "property": "theme.sidebery.hide-zen-tabbar",


### PR DESCRIPTION
This will prevent installing the theme from automatically and persistently enabling a transparent viewport, causing issues with background colour on many websites. This is a very important change due to the frequency of inexperienced users running into this problem.