### PR TITLE
Update theme: Zen Minimal Exit Menu

### DIFF
--- a/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/chrome.css
+++ b/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/chrome.css
@@ -1,59 +1,58 @@
 .titlebar-buttonbox {
-  margin-right: 20px;
+    margin-right: 20px;
 }
 
 .titlebar-button {
-  padding: 0px !important;
-  min-height: 13px !important;
-  min-width: 13px !important;
-  align-self: center;
-  margin-left: 5px !important;
-  border-radius: 50px;
-  transition: all 100ms;
+    padding: 0px !important;
+    min-height: 13px !important;
+    min-width: 13px !important;
+    height: 13px !important;
+    align-self: center;
+    margin-left: 5px !important;
+    border-radius: 50px;
+    transition: all 100ms;
 }
 
 .titlebar-min {
-  background-color: hsl(130, 50%, 40%) !important;
+    background-color: hsl(130, 50%, 40%) !important;
 }
 
-.titlebar-max,
-.titlebar-restore {
-  background-color: hsl(60, 50%, 50%) !important;
+.titlebar-max, .titlebar-restore {
+    background-color: hsl(60, 50%, 50%) !important;
 }
 
 .titlebar-close {
-  background-color: hsl(0, 50%, 50%) !important;
+    background-color: hsl(0, 50%, 50%) !important;
 }
 
 .titlebar-button > image {
-  visibility: collapse !important;
+    visibility: collapse !important;
 }
 
 @media (-moz-bool-pref: "theme.zen-minimal-exit-menu.enable-macos-identic") {
-  .titlebar-button:hover {
-    opacity: 0.25 !important;
-  }
+    .titlebar-button:hover {
+        opacity: 0.25 !important;
+    }
 }
 
 @media not (-moz-bool-pref: "theme.zen-minimal-exit-menu.enable-macos-identic") {
-  .titlebar-button {
-    background-color: var(--zen-colors-border) !important;
-  }
+    .titlebar-button {
+        background-color: var(--zen-colors-border) !important;
+    }
+    
+    .titlebar-min:hover {
+        background-color: hsl(130, 50%, 40%) !important;
+    }
 
-  .titlebar-min:hover {
-    background-color: hsl(130, 50%, 40%) !important;
-  }
+    .titlebar-max:hover, .titlebar-restore:hover {
+        background-color: hsl(60, 50%, 50%) !important;
+    }
 
-  .titlebar-max:hover,
-  .titlebar-restore:hover {
-    background-color: hsl(60, 50%, 50%) !important;
-  }
-
-  .titlebar-close:hover {
-    background-color: hsl(0, 50%, 50%) !important;
-  }
-
-  .titlebar-button:hover {
-    min-height: 20px !important;
-  }
+    .titlebar-close:hover {
+        background-color: hsl(0, 50%, 50%) !important;
+    }
+    
+    .titlebar-button:hover {
+        min-height: 20px !important;
+    }
 }

--- a/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/preferences.json
+++ b/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/preferences.json
@@ -1,34 +1,9 @@
 [
     {
-        "property": "property",
-        "label": "theme.zen-minimal-exit-menu.enable-macos-identic",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
-        "property": "label",
+        "property": "theme.zen-minimal-exit-menu.enable-macos-identic",
         "label": "Makes theme more identical to MacOS version.",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
-        "property": "defaultValue",
-        "label": "false",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
-        "property": "disabledOn",
-        "label": [
-            "macos"
-        ],
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
-        "property": "type",
-        "label": "checkbox",
-        "type": "checkbox",
-        "disabledOn": []
+        "defaultValue": "false",
+        "disabledOn": ["macos"],
+        "type": "checkbox"
     }
 ]

--- a/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/theme.json
+++ b/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/theme.json
@@ -8,7 +8,7 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/image.png",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/preferences.json",
     "author": "Dinno-DEV",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "tags": [],
     "createdAt": "2024-09-19",
     "updatedAt": "2025-01-26"


### PR DESCRIPTION
Re-pull request because the old one seems to be abandoned. This update allows the user to have the buttons colorful by default.