### PR TITLE
fix superpins, compatible twilight

### DIFF
--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
@@ -66,8 +66,8 @@
         width: 100%; /* Ensure enough space */
         max-width: 100%;
         
-        /* Force 3 columns */
-        grid-template-columns: repeat(3, minmax(var(--tab-pinned-min-width-expanded), 1fr)) !important;
+
+        grid-template-columns: repeat(auto-fit, minmax(var(--tab-pinned-min-width-expanded), auto)) !important;
       
         overflow: visible !important;
         flex: 1 !important;

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
@@ -1,282 +1,441 @@
-@media (-moz-bool-pref: "zen.tabs.vertical") {
-  /* Makes essentials transparent (when toggled) */
-  :root:has(#theme-SuperPins[uc-essentials-color-scheme="transparent"]) {
-    .tabbrowser-tab[zen-essential="true"]:not(:hover):not([selected="true"])
-      .tab-stack
-      .tab-background {
-      background-color: transparent !important;
-    }
-  }
-
-  @media (-moz-bool-pref: "zen.view.sidebar-expanded") and (not (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover")) {
-    /* Set width of Essentials (Dropdown) */
-    :root:has(#theme-SuperPins[uc-essentials-width="Thin"]) {
-      --essentials-width: 50px;
-    }
-    :root:has(#theme-SuperPins[uc-essentials-width="Normal"]) {
-      --essentials-width: 60px;
-    }
-    :root:has(#theme-SuperPins[uc-essentials-width="Wide"]) {
-      --essentials-width: 70px;
-    }
-
-    :root:has(
-        #theme-SuperPins[uc-essentials-width="Thin"],
-        #theme-SuperPins[uc-essentials-width="Normal"],
-        #theme-SuperPins[uc-essentials-width="Wide"]
-      ) {
-      #zen-essentials-container {
-        grid-template-columns: repeat(
-          auto-fit,
-          minmax(var(--essentials-width), auto)
-        ) !important;
+@-moz-document url-prefix("chrome:") {
+  @media (-moz-bool-pref: "zen.tabs.vertical") {
+    /* Makes essentials transparent (when toggled) */
+    :root:has(#theme-SuperPins[uc-essentials-color-scheme="transparent"]) {
+      .tabbrowser-tab[zen-essential="true"]:not(:hover):not([selected="true"])
+        .tab-stack
+        .tab-background {
+        background-color: transparent !important;
       }
     }
-
-    /* Set margin between Essentials (Dropdown) */
-    :root:has(#theme-SuperPins[uc-essentials-gap="Small"]) {
-      --essentials-gap: 0px;
-    }
-    :root:has(#theme-SuperPins[uc-essentials-gap="Normal"]) {
-      --essentials-gap: 2px;
-    }
-    :root:has(#theme-SuperPins[uc-essentials-gap="Big"]) {
-      --essentials-gap: 5px;
-    }
-
-    :root:has(
-        #theme-SuperPins[uc-essentials-gap="Small"],
-        #theme-SuperPins[uc-essentials-gap="Normal"],
-        #theme-SuperPins[uc-essentials-gap="Big"]
-      ) {
-      #zen-essentials-container {
-        gap: var(--essentials-gap) var(--essentials-gap) !important;
+  
+    @media (-moz-bool-pref: "zen.view.sidebar-expanded") and (not (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover")) {
+      /* Set width of Essentials (Dropdown) */
+      :root:has(#theme-SuperPins[uc-essentials-width="Thin"]) {
+        --essentials-width: 50px;
       }
-    }
-  }
-
-  /* Enables legacy layout for pinned tabs (icon only in grid) */
-  @media (-moz-bool-pref: "uc.pins.legacy-layout") {
-    #vertical-pinned-tabs-container .zen-workspace-tabs-section {
-      display: grid !important;
-      grid-template-columns: repeat(
-        auto-fit,
-        minmax(var(--tab-pinned-min-width-expanded), auto)
-      ) !important;
-      overflow-y: auto !important;
-      overflow-x: hidden !important;
-      scrollbar-width: thin !important;
-    }
-
-    #vertical-pinned-tabs-container .tab-close-button {
-      display: none !important;
-    }
-
-    #vertical-pinned-tabs-container .tab-label-container {
-      display: none !important;
-    }
-
-    #vertical-pinned-tabs-container .tab-icon-image {
-      margin: 0 !important;
-    }
-  }
-
-  /* Make Essentials look more box like */
-  @media (-moz-bool-pref: "uc.essentials.box-like-corners") {
-    .tabbrowser-tab[zen-essential="true"] .tab-stack .tab-background {
-      border-radius: 5px !important;
-    }
-  }
-
-  /* Adds a little bg to the pinned tabs */
-  @media (-moz-bool-pref: "uc.pins.bg") {
-    @media (prefers-color-scheme: light) {
-      :root {
-        --pins-bg-percentage: 40%;
+      :root:has(#theme-SuperPins[uc-essentials-width="Normal"]) {
+        --essentials-width: 60px;
       }
-    }
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --pins-bg-percentage: 7%;
+      :root:has(#theme-SuperPins[uc-essentials-width="Wide"]) {
+        --essentials-width: 70px;
       }
-    }
-
-    /* background color of pinned tabs in a normal state (not hovered/selected) */
-    .tabbrowser-tab[pinned]:not([zen-essential="true"])
-      .tab-stack
-      .tab-background {
-      background-color: color-mix(
-        in srgb,
-        white var(--pins-bg-percentage),
-        transparent
-      ) !important;
-    }
-
-    /* background color when hovering */
-    .tabbrowser-tab[pinned]:not([zen-essential="true"]):hover
-      .tab-stack
-      .tab-background {
-      background-color: color-mix(
-        in srgb,
-        white calc(var(--pins-bg-percentage) + 3%),
-        transparent
-      ) !important;
-    }
-
-    /* background color when selected */
-    .tabbrowser-tab[pinned]:not([zen-essential="true"])[selected="true"]
-      .tab-stack
-      .tab-background,
-    .tabbrowser-tab[pinned]:not([zen-essential="true"])[multiselected="true"]
-      .tab-stack
-      .tab-background {
-      background-color: color-mix(
-        in srgb,
-        white calc(var(--pins-bg-percentage) + 16%),
-        transparent
-      ) !important;
-    }
-
-    /* background color when selected and hovering*/
-    .tabbrowser-tab[pinned]:not([zen-essential="true"])[selected="true"]:hover
-      .tab-stack
-      .tab-background,
-    .tabbrowser-tab[pinned]:not(
-        [zen-essential="true"]
-      )[multiselected="true"]:hover
-      .tab-stack
-      .tab-background {
-      background-color: color-mix(
-        in srgb,
-        white calc(var(--pins-bg-percentage) + 18%),
-        transparent
-      ) !important;
-    }
-  }
-
-  /* Adds border to Pins/Essentials (when toggled) */
-  :root:has(#theme-SuperPins[uc-superpins-border="essentials"]) {
-    #zen-essentials-container
-      .tabbrowser-tab[zen-essential="true"]
-      .tab-stack
-      .tab-background {
-      border: 1px solid
-        light-dark(
-          color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
-          color-mix(in srgb, var(--zen-colors-secondary) 80%, white)
-        ) !important;
-    }
-  }
-
-  :root:has(#theme-SuperPins[uc-superpins-border="pins"]) {
-    .tabbrowser-tab[pinned]:not([zen-essential="true"])
-      .tab-stack
-      .tab-background {
-      border: 1px solid
-        light-dark(
-          color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
-          color-mix(in srgb, var(--zen-colors-secondary) 80%, white)
-        ) !important;
-    }
-  }
-
-  :root:has(#theme-SuperPins[uc-superpins-border="both"]) {
-    .tabbrowser-tab[pinned] .tab-stack .tab-background {
-      border: 1px solid
-        light-dark(
-          color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
-          color-mix(in srgb, var(--zen-colors-secondary) 80%, white)
-        ) !important;
-    }
-  }
-
-  /* Hides unloaded tabs when tab bar is collapsed (when toggled)*/
-  @media (not (-moz-bool-pref: "zen.view.sidebar-expanded")) {
-    :root:has(#theme-SuperPins[uc-pins-only-show-active="Normal"]) {
-      .tabbrowser-tab[pinned]:not([zen-essential="true"])[pending="true"] {
-        position: absolute !important;
-        /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
-        visibility: hidden !important;
-      }
-    }
-
-    /* Shows all pins when user is hovering over them when tab bar is collapsed */
-    :root:has(#theme-SuperPins[uc-pins-only-show-active="OnHover"]) {
-      .tabbrowser-tab[pinned]:not([zen-essential="true"])[pending="true"] {
-        position: absolute !important;
-        /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
-        visibility: hidden !important;
-      }
-
-      #vertical-pinned-tabs-container:hover
-        .tabbrowser-tab[pinned]:not([zen-essential="true"])[pending="true"] {
-        position: relative !important;
-        visibility: visible !important;
-      }
-
-      #vertical-pinned-tabs-container {
-        position: relative;
-      }
-
-      #vertical-pinned-tabs-container::before {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 10px;
-        background-color: transparent;
-      }
-
-      #vertical-pinned-tabs-container::before:hover
-        .tabbrowser-tab[pinned]:not([zen-essential="true"])[pending="true"] {
-        position: relative !important;
-        visibility: visible !important;
-      }
-    }
-  }
-
-  /* Hides unloaded tabs when tab bar is collapsed when in "Expand on hove" mode (when toggled) */
-  @media (-moz-bool-pref: "zen.view.sidebar-expanded") and (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover") {
-    :root:has(#theme-SuperPins[uc-pins-only-show-active="Normal"]),
-    :root:has(#theme-SuperPins[uc-pins-only-show-active="OnHover"]) {
-      #navigator-toolbox:not(
-          :is(
-              #navigator-toolbox[zen-has-hover],
-              #navigator-toolbox:focus-within,
-              #navigator-toolbox[movingtab],
-              #navigator-toolbox[flash-popup],
-              #navigator-toolbox[has-popup-menu],
-              #navigator-toolbox:has(.tabbrowser-tab:active),
-              #navigator-toolbox:has(
-                  *[open="true"]:not(tab):not(#zen-sidepanel-button)
-                )
-            )
+  
+      :root:has(
+          #theme-SuperPins[uc-essentials-width="Thin"],
+          #theme-SuperPins[uc-essentials-width="Normal"],
+          #theme-SuperPins[uc-essentials-width="Wide"]
         ) {
+        #zen-essentials-container {
+          grid-template-columns: repeat(
+            auto-fit,
+            minmax(var(--essentials-width), auto)
+          ) !important;
+        }
+      }
+  
+      /* Set margin between Essentials (Dropdown) */
+      :root:has(#theme-SuperPins[uc-essentials-gap="Small"]) {
+        --essentials-gap: 0px;
+      }
+      :root:has(#theme-SuperPins[uc-essentials-gap="Normal"]) {
+        --essentials-gap: 2px;
+      }
+      :root:has(#theme-SuperPins[uc-essentials-gap="Big"]) {
+        --essentials-gap: 5px;
+      }
+  
+      :root:has(
+          #theme-SuperPins[uc-essentials-gap="Small"],
+          #theme-SuperPins[uc-essentials-gap="Normal"],
+          #theme-SuperPins[uc-essentials-gap="Big"]
+        ) {
+        #zen-essentials-container {
+          gap: var(--essentials-gap) var(--essentials-gap) !important;
+        }
+      }
+    }
+  
+    /* Enables legacy layout for pinned tabs (icon only in grid) */
+
+    @media (-moz-bool-pref: "uc.pins.legacy-layout") {
+      #vertical-pinned-tabs-container {
+        display: grid !important;
+        position: relative !important;
+        box-sizing: border-box;
+        width: 100%; /* Ensure enough space */
+        max-width: 100%;
+        
+        /* Force 3 columns */
+        grid-template-columns: repeat(3, minmax(var(--tab-pinned-min-width-expanded), 1fr)) !important;
+      
+        overflow: visible !important;
+        flex: 1 !important;
+        scrollbar-width: thin !important;
+        
+        --tab-selected-bgcolor: light-dark(rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.2));
+        --tab-min-height: 44px;
+        
+        overflow: hidden;
+        transition: max-height 0.3s ease-out;
+        opacity: 1;
+        padding: 0;
+      }
+
+      #vertical-pinned-tabs-container > .zen-workspace-tabs-section {
+        display: grid !important;
+        grid-template-columns: repeat(3, minmax(var(--tab-pinned-min-width-expanded), 1fr)) !important;
+        gap: 2px; 
+      }
+
+      .vertical-pinned-tabs-container-separator{
+        position: fixed !important; 
+        align-self: end !important; 
+        margin-bottom: -3px !important;
+      }
+      
+
+      #vertical-pinned-tabs-container > .zen-workspace-tabs-section > .tabbrowser-tab {
+        justify-content: center !important;
+  --toolbarbutton-inner-padding: 0 !important;
+  max-width: unset !important;
+  width: 100% !important;
+  
+  & .tab-background {
+    border-radius: var(--border-radius-medium) !important;
+    transition: background 0.1s ease-in-out !important;
+  }
+
+  --tab-selected-bgcolor: light-dark(rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.2));
+
+  &:not([visuallyselected], [multiselected="true"]) .tab-background {
+    background: var(--zen-toolbar-element-bg) !important;
+    border: none !important;
+  }
+
+  & .tab-content {
+    display: flex !important;
+    justify-content: center !important;
+  }
+
+  & .tab-label-container {
+    display: none !important;
+  }
+
+  & .tab-close-button {
+    display: none !important;
+  }
+
+  & .tab-icon-image,
+  & .tab-icon-overlay {
+    margin-inline-end: 0 !important;
+  }
+
+  &:hover .tab-background {
+    background: var(--tab-selected-bgcolor) !important;
+  }
+
+  @media (-moz-bool-pref: 'zen.theme.essentials-favicon-bg') {
+    &[visuallyselected] > .tab-stack > .tab-background {
+      &::after {
+        content: "";
+        inset: -50%;
+        filter: blur(15px);
+        position: absolute;
+        background-size: 100% 100%;
+        background-clip: padding-box;
+        background-image: var(--zen-tab-icon);
+        z-index: -1;
+      }
+
+      background: transparent !important;
+      overflow: hidden !important;
+      position: relative !important;
+      --zen-essential-bg-margin: 2px !important;
+
+      &::before {
+        background: light-dark(rgba(255, 255, 255, 0.85), rgba(68, 64, 64, 0.85)) !important;
+        margin: var(--zen-essential-bg-margin);
+        border-radius: calc(var(--border-radius-medium) - var(--zen-essential-bg-margin));
+        position: absolute;
+        inset: 0;
+        z-index: 0;
+        content: "";
+        transition: background 0.1s ease-in-out;
+      }
+    }
+
+    &[visuallyselected]:hover .tab-background::before {
+      background: light-dark(rgba(255, 255, 255, 0.80), rgba(68, 64, 64, 0.80)) !important;
+    }
+  }
+}
+      
+  
+      #vertical-pinned-tabs-container > vbox:nth-child(1) > tab > stack:nth-child(1) > hbox:nth-child(2) > image:nth-child(4), 
+      #vertical-pinned-tabs-container > vbox:nth-child(1) > tab > stack:nth-child(1) > hbox:nth-child(2) > image:nth-child(5) {
+        display: none !important;
+      }
+  
+      #vertical-pinned-tabs-container .tab-label-container {
+        display: none !important;
+      }
+  
+      #vertical-pinned-tabs-container .tab-icon-image {
+        margin: 0 !important;
+      }
+
+        /* fix glance */ 
+        #vertical-pinned-tabs-container > .zen-workspace-tabs-section > .tabbrowser-tab > .tab-stack > .tab-content > .tabbrowser-tab {
+              position: relative !important;
+              overflow: visible !important;
+              top: -10px;
+              right: -8px;
+              --tab-collapsed-width: 34px;
+              --tab-min-height: 16px;
+              width: var(--tab-collapsed-width) !important;
+              z-index: 9999 !important;
+              pointer-events: none;
+              & .tab-background {
+                /* Solid colors because we don't want to show the background */
+                background: light-dark(rgb(249, 249, 249), rgb(63, 63, 63)) !important;
+                border: 2px solid light-dark(rgba(0, 0, 0, 0.4), rgba(255, 255, 255, 0.4));
+              }
+            }
+
+          /* borders */ 
+
+          #vertical-pinned-tabs-container > .zen-workspace-tabs-section > .tabbrowser-tab {
+        
+          &[visuallyselected] > .tab-stack > .tab-background {
+            &::after {
+              content: "";
+              inset: -50%;
+              filter: blur(15px);
+              position: absolute;
+              background-size: 100% 100%;
+              background-clip: padding-box;
+              background-image: var(--zen-tab-icon);
+              z-index: -1;
+            }
+
+            &::before {
+              background: light-dark(rgba(255, 255, 255, 0.85), rgba(68, 64, 64, 0.85));
+              margin: var(--zen-essential-bg-margin);
+              border-radius: calc(var(--border-radius-medium) - var(--zen-essential-bg-margin));
+              position: absolute;
+              inset: 0;
+              z-index: 0;
+              content: "";
+              transition: background 0.1s ease-in-out;
+            }
+          } 
+
+
+
+    }
+  }
+
+    
+  
+    /* Make Essentials look more box like */
+    @media (-moz-bool-pref: "uc.essentials.box-like-corners") {
+      .tabbrowser-tab[zen-essential="true"] .tab-stack .tab-background {
+        border-radius: 5px !important;
+      }
+    }
+  
+    /* Adds a little bg to the pinned tabs */
+    @media (-moz-bool-pref: "uc.pins.bg") {
+      @media (prefers-color-scheme: light) {
+        :root {
+          --pins-bg-percentage: 40%;
+        }
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --pins-bg-percentage: 7%;
+        }
+      }
+  
+      /* background color of pinned tabs in a normal state (not hovered/selected) */
+      .tabbrowser-tab[pinned]:not([zen-essential="true"])
+        .tab-stack
+        .tab-background {
+        background-color: color-mix(
+          in srgb,
+          white var(--pins-bg-percentage),
+          transparent
+        ) !important;
+      }
+  
+      /* background color when hovering */
+      .tabbrowser-tab[pinned]:not([zen-essential="true"]):hover
+        .tab-stack
+        .tab-background {
+        background-color: color-mix(
+          in srgb,
+          white calc(var(--pins-bg-percentage) + 3%),
+          transparent
+        ) !important;
+      }
+  
+      /* background color when selected */
+      .tabbrowser-tab[pinned]:not([zen-essential="true"])[selected="true"]
+        .tab-stack
+        .tab-background,
+      .tabbrowser-tab[pinned]:not([zen-essential="true"])[multiselected="true"]
+        .tab-stack
+        .tab-background {
+        background-color: color-mix(
+          in srgb,
+          white calc(var(--pins-bg-percentage) + 16%),
+          transparent
+        ) !important;
+      }
+  
+      /* background color when selected and hovering*/
+      .tabbrowser-tab[pinned]:not([zen-essential="true"])[selected="true"]:hover
+        .tab-stack
+        .tab-background,
+      .tabbrowser-tab[pinned]:not(
+          [zen-essential="true"]
+        )[multiselected="true"]:hover
+        .tab-stack
+        .tab-background {
+        background-color: color-mix(
+          in srgb,
+          white calc(var(--pins-bg-percentage) + 18%),
+          transparent
+        ) !important;
+      }
+    }
+  
+    /* Adds border to Pins/Essentials (when toggled) */
+    :root:has(#theme-SuperPins[uc-superpins-border="essentials"]) {
+      #zen-essentials-container
+        .tabbrowser-tab[zen-essential="true"]
+        .tab-stack
+        .tab-background {
+        border: 1px solid
+          light-dark(
+            color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
+            color-mix(in srgb, var(--zen-colors-secondary) 80%, white)
+          ) !important;
+      }
+    }
+  
+    :root:has(#theme-SuperPins[uc-superpins-border="pins"]) {
+      .tabbrowser-tab[pinned]:not([zen-essential="true"])
+        .tab-stack
+        .tab-background {
+        border: 1px solid
+          light-dark(
+            color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
+            color-mix(in srgb, var(--zen-colors-secondary) 80%, white)
+          ) !important;
+      }
+    }
+  
+    :root:has(#theme-SuperPins[uc-superpins-border="both"]) {
+      .tabbrowser-tab[pinned] .tab-stack .tab-background {
+        border: 1px solid
+          light-dark(
+            color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
+            color-mix(in srgb, var(--zen-colors-secondary) 80%, white)
+          ) !important;
+      }
+    }
+  
+    /* Hides unloaded tabs when tab bar is collapsed (when toggled)*/
+    @media (not (-moz-bool-pref: "zen.view.sidebar-expanded")) {
+      :root:has(#theme-SuperPins[uc-pins-only-show-active="Normal"]) {
         .tabbrowser-tab[pinned]:not([zen-essential="true"])[pending="true"] {
           position: absolute !important;
           /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
           visibility: hidden !important;
         }
       }
+  
+      /* Shows all pins when user is hovering over them when tab bar is collapsed */
+      :root:has(#theme-SuperPins[uc-pins-only-show-active="OnHover"]) {
+        .tabbrowser-tab[pinned]:not([zen-essential="true"])[pending="true"] {
+          position: absolute !important;
+          /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
+          visibility: hidden !important;
+        }
+  
+        #vertical-pinned-tabs-container:hover
+          .tabbrowser-tab[pinned]:not([zen-essential="true"])[pending="true"] {
+          position: relative !important;
+          visibility: visible !important;
+        }
+  
+        #vertical-pinned-tabs-container {
+          position: relative;
+        }
+  
+        #vertical-pinned-tabs-container::before {
+          content: "";
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 10px;
+          background-color: transparent;
+        }
+  
+        #vertical-pinned-tabs-container::before:hover
+          .tabbrowser-tab[pinned]:not([zen-essential="true"])[pending="true"] {
+          position: relative !important;
+          visibility: visible !important;
+        }
+      }
+    }
+  
+    /* Hides unloaded tabs when tab bar is collapsed when in "Expand on hove" mode (when toggled) */
+    @media (-moz-bool-pref: "zen.view.sidebar-expanded") and (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover") {
+      :root:has(#theme-SuperPins[uc-pins-only-show-active="Normal"]),
+      :root:has(#theme-SuperPins[uc-pins-only-show-active="OnHover"]) {
+        #navigator-toolbox:not(
+            :is(
+                #navigator-toolbox[zen-has-hover],
+                #navigator-toolbox:focus-within,
+                #navigator-toolbox[movingtab],
+                #navigator-toolbox[flash-popup],
+                #navigator-toolbox[has-popup-menu],
+                #navigator-toolbox:has(.tabbrowser-tab:active),
+                #navigator-toolbox:has(
+                    *[open="true"]:not(tab):not(#zen-sidepanel-button)
+                  )
+              )
+          ) {
+          .tabbrowser-tab[pinned]:not([zen-essential="true"])[pending="true"] {
+            position: absolute !important;
+            /* Using position: absolute and visibility: hidden instead of display:none stops the icons of unloaded tabs from loading when sidebar expands */
+            visibility: hidden !important;
+          }
+        }
+      }
+    }
+  
+    /* Let pinned tabs have the same selected styling as essentials */
+    @media (-moz-bool-pref: "uc.pins.essentials-layout") {
+      #vertical-pinned-tabs-container .zen-workspace-tabs-section {
+        grid-template-columns: repeat(
+          auto-fit,
+          minmax(var(--essentials-width), auto)
+        ) !important;
+        gap: var(--essentials-gap) var(--essentials-gap) !important;
+      }
+    }
+  
+    /* Hide reset button on pinned tabs */
+    @media (-moz-bool-pref: "uc.pins.hide-reset-button") {
+      #vertical-pinned-tabs-container .tab-reset-button {
+        display: none !important;
+      }
     }
   }
-
-  /* Let pinned tabs have the same selected styling as essentials */
-  @media (-moz-bool-pref: "uc.pins.essentials-layout") {
-    #vertical-pinned-tabs-container .zen-workspace-tabs-section {
-      grid-template-columns: repeat(
-        auto-fit,
-        minmax(var(--essentials-width), auto)
-      ) !important;
-      gap: var(--essentials-gap) var(--essentials-gap) !important;
-    }
-  }
-
-  /* Hide reset button on pinned tabs */
-  @media (-moz-bool-pref: "uc.pins.hide-reset-button") {
-    #vertical-pinned-tabs-container .tab-reset-button {
-      display: none !important;
-    }
-  }
+  
 }


### PR DESCRIPTION
Fix the "Makes pinned tabs look similar to Essentials (icon only in a grid)" option. Compatible with Zen twilight only as this will most likely require fixing until stable release. 

The only thing that I couldn't fix was making the border of the essentials-like pinned tabs as the img of pinned tabs aren't exposed through --zen-tab-icon the way it is for essential tabs. The code is here though so it will work if/when they get exposed. 