### PR TITLE
Update: Zen Minimal Exit Menu

### DIFF
--- a/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/chrome.css
+++ b/themes/6cd4bca9-f17d-4461-b554-844d69a4887c/chrome.css
@@ -2,6 +2,10 @@
     margin-right: 20px;
 }
 
+#zen-sidebar-top-buttons .titlebar-buttonbox {
+  margin-top: 10px;
+}
+
 .titlebar-button {
     padding: 0px !important;
     min-height: 13px !important;


### PR DESCRIPTION
This PR fixes Zen Minimal Exit Menu's position in right sidebar.
![image](https://github.com/user-attachments/assets/afc15322-f1ce-4ea5-ad7d-653e36eef011)
