### PR TITLE
Fixes broken Zen browser logo on theme store Github page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <picture>
-    <img src="https://github.com/zen-browser/.github/blob/main/profile/logo-black.png" width="128px">
+    <img src="https://raw.githubusercontent.com/zen-browser/.github/refs/heads/main/profile/logo-black.png" width="128px">
 </picture>
 </div>
 <h1 align="center">


### PR DESCRIPTION
The image source for the Zen browser logo in `README.md` references `https://github.com/zen-browser/.github/blob/main/profile/logo-black.png`.

This works correctly when reading the page on github.com, but fails to load when accessing https://zen-browser.github.io/theme-store/

![theme-store-img-src](https://github.com/user-attachments/assets/d5e1f618-b2b1-48d5-819b-4024da2a029b)
