### PR TITLE
Update theme: Bigger Mute Button

### DIFF
--- a/themes/5c4d7772-d963-4672-ab03-e9d541438881/chrome.css
+++ b/themes/5c4d7772-d963-4672-ab03-e9d541438881/chrome.css
@@ -1,33 +1,36 @@
 .tab-icon-overlay {
-  opacity: 1 !important;
-  margin: initial !important;
-  border: none !important;
-  margin-right: 32px !important;
-  transform: translate(120%, 50%) scale(1.6) !important;
-  color: light-dark(black, white) !important;
-  background-color: transparent !important;
-  transition: 0.3s !important;
-}
-
-.tab-icon-overlay:hover {
-  color: var(--zen-primary-color) !important;
-  transition: 0.3s !important;
-}
-
-.tab-icon-overlay:is([soundplaying], [muted]):not([selected]) {
-  display: block !important;
-}
-
-/* Hide sound labels */
-.tab-icon-sound-label,
-.tab-icon-sound-playing-label {
-  display: none !important;
+    opacity: 1 !important;
+    margin: initial !important;
+    border: none !important;
+    margin-right: 35px !important;
+    transform: translate(130%, 45%) scale(1.5) !important;
+    background-color: transparent !important;
+    fill: light-dark(black, white) !important;
+    transition: 0.2s;
+    
+    &:hover {
+        fill: var(--zen-primary-color) !important;
+        transition: 0.2s;
+    }
+    
+    &:is([soundplaying], [muted]):not([selected]) {
+        display: block !important;
+    }
 }
 
 /* Mute button takes place of tab icon when tabs are not expanded */
 @media not (-moz-bool-pref: "zen.view.sidebar-expanded") {
-  .tab-icon-overlay {
-    margin: auto 30px !important;
-    transform: translate(-35%, 50%) scale(1.6) !important;
-  }
+    .tab-icon-overlay {
+        margin: 0px !important;
+        transform: translate(-35%, 50%) scale(1.5) !important;
+    
+        /* Prevent button from being toggled if tab is not selected */
+        &:is([soundplaying], [muted]):not([selected]) {
+            pointer-events: none !important;
+        }
+    }
+    
+    .tabbrowser-tab:is([soundplaying], [muted]) .tab-icon-image {
+        display: none !important;
+    }
 }


### PR DESCRIPTION
Adjusted sound icon size/position; changed toggling in compact:
- Increased size and margin, and vertically centered new Zen sound playing icon in the tab.
- When in compact mode or with sidebar collapsed: Removed pointer events for sound playing button if tab is not the currently selected tab. Prevents unintentional toggling of the sound button when selecting or moving a tab with sound playing.