### PR TITLE
Update Theme: Vertical Tab Groups

### DIFF
--- a/themes/4c2bec61-7f6c-4e5c-bdc6-c9ad1aba1827/readme.md
+++ b/themes/4c2bec61-7f6c-4e5c-bdc6-c9ad1aba1827/readme.md
@@ -1,4 +1,4 @@
 
-# Vertical Tab Groups
+# Vertical Split Tab Groups
 
-Display tab groups vertically so you can still read the page names.
+Display tab groups created from split tabs as vertical lists instead of horizontal ones.

--- a/themes/4c2bec61-7f6c-4e5c-bdc6-c9ad1aba1827/theme.json
+++ b/themes/4c2bec61-7f6c-4e5c-bdc6-c9ad1aba1827/theme.json
@@ -1,8 +1,8 @@
 {
     "id": "4c2bec61-7f6c-4e5c-bdc6-c9ad1aba1827",
-    "name": "Vertical Split Views",
-    "description": "Display tab groups vertically so you can still read the page names",
-    "homepage": "https://github.com/ToBinio/zen-mods/tree/main/vertical-tab-groups",
+    "name": "Vertical Split Tab Groups",
+    "description": "Display tab groups created from split tabs as vertical lists instead of horizontal ones.",
+    "homepage": "https://github.com/ToBinio/zen-mods/tree/main/vertical-split-tab-groups",
     "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4c2bec61-7f6c-4e5c-bdc6-c9ad1aba1827/chrome.css",
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4c2bec61-7f6c-4e5c-bdc6-c9ad1aba1827/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4c2bec61-7f6c-4e5c-bdc6-c9ad1aba1827/image.png",


### PR DESCRIPTION
Rename "Vertical Tab Groups" to "Vertical Split Tab Groups" and update description to clear up confusion about the experimental "Tab Groups" feature