### PR TITLE
Update theme: Transparent Zen

### DIFF
--- a/themes/642854b5-88b4-4c40-b256-e035532109df/chrome.css
+++ b/themes/642854b5-88b4-4c40-b256-e035532109df/chrome.css
@@ -45,7 +45,7 @@ hbox.browserSidebarContainer,
 /* Tab switch animation */
 #tabbrowser-tabpanels
   > hbox:not([zen-split="true"]):not(:has(.zen-glance-background)) {
-  @media (-moz-bool-pref: "mod.sameerasw.zen_tab_switch_animation") {
+  @media (-moz-bool-pref: "mod.sameerasw.zen_tab_switch_anim") {
     transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.35),
       filter 0.45s ease-in-out, opacity 0.35s ease-in-out !important;
     scale: 0.9 !important;
@@ -53,7 +53,7 @@ hbox.browserSidebarContainer,
   }
 }
 #tabbrowser-tabpanels > hbox.deck-selected:not([zen-split="true"]) {
-  @media (-moz-bool-pref: "mod.sameerasw.zen_tab_switch_animation") {
+  @media (-moz-bool-pref: "mod.sameerasw.zen_tab_switch_anim") {
     scale: 1 !important;
     opacity: 1 !important;
   }

--- a/themes/642854b5-88b4-4c40-b256-e035532109df/preferences.json
+++ b/themes/642854b5-88b4-4c40-b256-e035532109df/preferences.json
@@ -6,6 +6,13 @@
     "defaultvalue": true
   },
   {
+    "property": "zen.widget.linux.transparency",
+    "label": "Allow zen browser on linux to be transparent (Turn off before uninstall)",
+    "type": "checkbox",
+    "defaultvalue": true,
+    "disabledOn": ["windows", "macos"]
+  },
+  {
     "property": "mod.sameerasw.zen_bg_color_enabled",
     "label": "Enable custom background color for Zen",
     "type": "checkbox",

--- a/themes/642854b5-88b4-4c40-b256-e035532109df/theme.json
+++ b/themes/642854b5-88b4-4c40-b256-e035532109df/theme.json
@@ -1,15 +1,15 @@
 {
     "id": "642854b5-88b4-4c40-b256-e035532109df",
     "name": "Transparent Zen",
-    "description": "Make the Zen Browser's background transparent and modify the empty tab page and ahve animations that goes along with the transparency. Turn off transparency in mod settings before uninstallation.",
+    "description": "Make the Zen Browser's background transparent and modify the empty tab page and have animations that goes along with the transparency. Turn off transparency in mod settings before uninstallation.",
     "homepage": "https://github.com/sameerasw/zen-themes/tree/main/TransparentZen",
     "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/642854b5-88b4-4c40-b256-e035532109df/chrome.css",
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/642854b5-88b4-4c40-b256-e035532109df/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/642854b5-88b4-4c40-b256-e035532109df/image.png",
     "author": "sameerasw",
-    "version": "1.11.2",
+    "version": "1.11.2b",
     "tags": [],
     "createdAt": "2025-02-04",
-    "updatedAt": "2025-04-11",
+    "updatedAt": "2025-04-12",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/642854b5-88b4-4c40-b256-e035532109df/preferences.json"
 }


### PR DESCRIPTION
## Updates for 1.11.2b and minor fixes

This pull request includes a few changes to the `Transparent Zen` theme for the Zen Browser to **fix a typo**, update media query preferences, and add a **new preference for Linux transparency.**

### Fixes and Updates:

* **Fix tab switch animation:**
  - Updated the media query preference name from `mod.sameerasw.zen_tab_switch_animation` to `mod.sameerasw.zen_tab_switch_anim` in `chrome.css` to ensure consistency.

* **Typo Fix:**
  - Corrected a typo in the `description` field of `theme.json` from "ahve" to "have."

### New Features:

* **Linux Transparency Preference:**
  - Added a new preference in `preferences.json` to allow the Zen Browser on Linux to be transparent, with a checkbox option and a note to turn off before uninstalling. This preference is disabled on Windows and macOS.