### PR TITLE
Update Mod: SuperPins

### DIFF
--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
@@ -224,11 +224,20 @@
 
     /* Puts Essentials at the bottom */
     :has(#theme-SuperPins[uc-essentials-position="bottom"]) {
-        #zen-essentials-container, .zen-essentials-container {
+        #zen-essentials-container, #zen-essentials-wrapper {
             order: 999 !important;
             margin-top: auto !important;
             padding-top: 5px !important;
             padding-bottom: 4px !important;
+        }
+
+        .zen-essentials-container {
+            position: relative !important;
+            min-width: 100% !important;
+        }
+
+        .zen-current-workspace-indicator, #zen-tabs-wrapper {
+            margin-top: 0 !important;
         }
     }
 

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json
@@ -76,7 +76,7 @@
     },
     {
         "property": "uc.essentials.position",
-        "label": "Select the position of Essentials",
+        "label": "Select the position of Essentials (doesn't work on >1.11.5t with container-specific essentials)",
         "type": "dropdown",
         "placeholder": "Top",
         "disabledOn": [],

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
@@ -7,7 +7,7 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/image.png",
     "author": "CosmoCreeper",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json",
     "tags": [
         "tabs"


### PR DESCRIPTION
- Updated "theme.json" to state that position of Essentials won't work with container-specific Essentials and version greater than 1.11.5t.

Mod changes:
- Fixed Twilight issue which caused Bottom Essentials to no longer work. (only works on non container-specific Essentials.)