### PR TITLE
Update theme: Bigger Mute Button

### DIFF
--- a/themes/5c4d7772-d963-4672-ab03-e9d541438881/chrome.css
+++ b/themes/5c4d7772-d963-4672-ab03-e9d541438881/chrome.css
@@ -1,10 +1,15 @@
 :root {
   --bmb-sound-icon-scale: 1.5;
-  --bmb-sound-icon-scale-essentials: 1.28;
+  --bmb-sound-icon-scale-essentials: 1.26;
   --bmb-sound-icon-scale-glance: 1.15;
 }
 
 /* ================== General ================== */
+/* Hide firefox sound button */
+.tab-audio-button {
+  display: none !important;
+}
+
 /* Tab icon overlay styles */
 .tab-icon-overlay {
   border: none !important;
@@ -12,7 +17,7 @@
   background-color: transparent !important;
   transition: 0.2s;
 
-  &:is([soundplaying], [muted], [activemedia-blocked]):not([selected]) {
+  &:is([soundplaying], [muted], [activemedia-blocked]) {
     display: block !important;
   }
 }
@@ -58,7 +63,7 @@
     & .tab-icon-overlay,
     & .tab-icon-stack {
       &:is([soundplaying], [muted], [activemedia-blocked]) {
-        transform: translate(20%, 24%)
+        transform: translate(20%, 25%)
           scale(var(--bmb-sound-icon-scale-essentials)) !important;
         display: block !important;
         /* Remove extra margin created for vanilla icons */
@@ -84,8 +89,7 @@
     & .tab-icon-overlay,
     & .tab-icon-stack {
       &:is([soundplaying], [muted], [activemedia-blocked]) {
-        transform: translate(-10%, 25%)
-          scale(var(--bmb-sound-icon-scale-glance)) !important;
+        transform: translate(-8%, 25%) scale(var(--bmb-sound-icon-scale-glance)) !important;
         display: block !important;
         margin: 0px !important;
       }
@@ -93,7 +97,7 @@
   }
 }
 
-/* ================== Zen glance tab (pinned and essentials) ================== */
+/* ================== Zen glance tab (pinned tabs) ================== */
 #navigator-toolbox[zen-sidebar-expanded]
   #tabbrowser-tabs
   .tabbrowser-tab[zen-glance-tab] {
@@ -104,7 +108,7 @@
   & .tab-icon-overlay {
     &:is([soundplaying], [muted], [activemedia-blocked]) {
       margin: 0px !important;
-      transform: translate(-35%, 25%) scale(var(--bmb-sound-icon-scale-glance)) !important;
+      transform: translate(-30%, 25%) scale(var(--bmb-sound-icon-scale-glance)) !important;
       display: block !important;
     }
   }

--- a/themes/5c4d7772-d963-4672-ab03-e9d541438881/chrome.css
+++ b/themes/5c4d7772-d963-4672-ab03-e9d541438881/chrome.css
@@ -108,7 +108,7 @@
   & .tab-icon-overlay {
     &:is([soundplaying], [muted], [activemedia-blocked]) {
       margin: 0px !important;
-      transform: translate(-30%, 25%) scale(var(--bmb-sound-icon-scale-glance)) !important;
+      transform: translate(-35%, 25%) scale(var(--bmb-sound-icon-scale-glance)) !important;
       display: block !important;
     }
   }


### PR DESCRIPTION
Made a few minor changes following the browser update to v1.12b:
- Hid the new sound icon (`.tab-audio-button`) which was displaying simultaneously with bigger mute button.
- Fixed an issue where the sound icon was not showing if the tab was not selected.
- Minor adjustments to sound icon scale and position.