### PR TITLE
Update Theme: Better Find Bar

### DIFF
--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/chrome.css
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/chrome.css
@@ -18,7 +18,7 @@ findbar {
 	margin: 0px !important;
 
 	width: 90% !important;
-	max-width: 800px;
+	max-width: calc(var(--theme-better_find_bar-textbox_width) * 1px); 
 
 	height: auto !important;
 
@@ -82,6 +82,7 @@ body:has(
 	--better-findbar-position-right: 15px;
 }
 
+/* Vertical Position */
 body:has(
 		#theme-Better-Find-Bar[theme-better_find_bar-vertical_position="top"]
 	) {
@@ -101,5 +102,87 @@ body:has(
 
 	findbar .findbar-textbox:not([status="notfound"]) {
 		background: color-mix(in hsl, var(--zen-colors-tertiary), transparent 10%) !important;
+	}
+}
+
+/* Hide highlight checkbox */
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_immediately"]
+	) {
+	findbar .findbar-highlight {
+		display: none !important;
+	}
+}
+
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_on_disable"]
+	) {
+	findbar checkbox.findbar-highlight:not([checked]) {
+		display: none !important;
+	}
+}
+
+/* Hide match case checkbox */
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_immediately"]
+	) {
+	findbar .findbar-case-sensitive {
+		display: none !important;
+	}
+}
+
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_on_disable"]
+	) {
+	findbar checkbox.findbar-case-sensitive:not([checked]) {
+		display: none !important;
+	}
+}
+
+/* Hide match diacritics checkbox */
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_immediately"]
+	) {
+	findbar .findbar-match-diacritics {
+		display: none !important;
+	}
+}
+
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_on_disable"]
+	) {
+	findbar checkbox.findbar-match-diacritics:not([checked]) {
+		display: none !important;
+	}
+}
+
+/* Hide whole words checkbox */
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_immediately"]
+	) {
+	findbar .findbar-entire-word {
+		display: none !important;
+	}
+}
+
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_on_disable"]
+	) {
+	findbar .findbar-entire-word:not([checked]) {
+		display: none !important;
+	}
+}
+
+/* Hide find status label */
+@media (-moz-bool-pref: "theme.better_find_bar.hide_find_status") {
+	findbar .findbar-find-status {
+		display: none !important;
+	}
+}
+
+/* Hide found matches label */
+@media (-moz-bool-pref: "theme.better_find_bar.hide_found_matches") {
+	findbar .findbar-label.found-matches {
+		display: none !important;
 	}
 }

--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/preferences.json
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/preferences.json
@@ -2,14 +2,15 @@
     {
         "property": "theme.better_find_bar.transparent_background",
         "label": "Transparent background",
-        "type": "checkbox"
+        "type": "checkbox",
+        "defaultValue": true
     },
     {
         "property": "theme.better_find_bar.horizontal_position",
         "label": "Horizontal position",
         "type": "dropdown",
         "disabledOn": [],
-        "placeholder": "Select horizontal position",
+        "placeholder": "Use default",
         "defaultValue": "default",
         "options": [
             {
@@ -31,7 +32,7 @@
         "label": "Vertical position",
         "type": "dropdown",
         "disabledOn": [],
-        "placeholder": "Select vertical position",
+        "placeholder": "Use default",
         "defaultValue": "default",
         "options": [
             {
@@ -43,5 +44,95 @@
                 "value": "default"
             }
         ]
+    },
+    {
+        "property": "theme.better_find_bar.textbox_width",
+        "label": "Textbox width (px)",
+        "type": "string",
+        "defaultValue": "800"
+    },
+    {
+        "property": "theme.better_find_bar.hide_highlight",
+        "label": "Hide \"highlight\" checkbox",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Show",
+        "defaultValue": "not_hide",
+        "options": [
+            {
+                "label": "Hide",
+                "value": "hide_immediately"
+            },
+            {
+                "label": "Show only when checked",
+                "value": "hide_on_disable"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.hide_match_case",
+        "label": "Hide \"match case\" checkbox",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Show",
+        "defaultValue": "not_hide",
+        "options": [
+            {
+                "label": "Hide",
+                "value": "hide_immediately"
+            },
+            {
+                "label": "Show only when checked",
+                "value": "hide_on_disable"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.hide_match_diacritics",
+        "label": "Hide \"match diacritics\" checkbox",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Show",
+        "defaultValue": "not_hide",
+        "options": [
+            {
+                "label": "Hide",
+                "value": "hide_immediately"
+            },
+            {
+                "label": "Show only when checked",
+                "value": "hide_on_disable"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.hide_whole_words",
+        "label": "Hide \"whole words\" checkbox",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Show",
+        "defaultValue": "not_hide",
+        "options": [
+            {
+                "label": "Hide",
+                "value": "hide_immediately"
+            },
+            {
+                "label": "Show only when checked",
+                "value": "hide_on_disable"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.hide_find_status",
+        "label": "Hide find status label",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "theme.better_find_bar.hide_found_matches",
+        "label": "Hide found matches label",
+        "type": "checkbox",
+        "defaultValue": false
     }
 ]

--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/readme.md
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/readme.md
@@ -1,3 +1,3 @@
 # Better Find Bar
 
-Improves the find bar by matching the browser theme, making it floating and more responsive.
+Improves the find bar, making it floating with theme match and customization.

--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/theme.json
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/theme.json
@@ -1,15 +1,15 @@
 {
     "id": "a6335949-4465-4b71-926c-4a52d34bc9c0",
     "name": "Better Find Bar",
-    "description": "Improves the find bar, making it floating, more responsive, and moving it to the top of the page.",
+    "description": "Improves the find bar, making it floating with theme match and customization.",
     "homepage": "https://github.com/RobotoSkunk/zen-better-findbar",
     "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/chrome.css",
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/image.png",
     "author": "RobotoSkunk",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/preferences.json",
-    "version": "1.2.0",
-    "tags": [],
+    "version": "1.3.0",
+    "tags": [ "find", "bar", "search", "searchbar", "find-bar" ],
     "createdAt": "2024-11-24",
-    "updatedAt": "2025-05-10"
+    "updatedAt": "2025-05-22"
 }


### PR DESCRIPTION
Changelog:
- Updated to 1.3.0
- Added options to change the find bar width and hide checkboxes (thanks to @Nepaletka!).
- Added options to hide the Find Status label and the Found Matches label.
- Defaulting Transparent Background to true.
- Renamed horizontal and vertical position placeholders to "Use default".
- Added more tags in the theme.json file.
- Changed mod description.
- Honestly, I like how clean the find bar looks with all options hidden :+1: 