### PR TITLE
Update Theme: Tab Numbers (v1.0.7)

### DIFF
--- a/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/chrome.css
+++ b/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/chrome.css
@@ -5,10 +5,7 @@ tabs {
   counter-reset: tab-counter;
 } /* Automatically increment tab numbers for each .tab-content inside a tab */ /* Styles when the sidebar is expanded */
 @media (-moz-bool-pref: "zen.view.sidebar-expanded") {
-  .zen-workspace-tabs-section[active="true"]
-    tab:not([zen-glance-tab="true"])
-    > .tab-stack
-    > .tab-content::after {
+  tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::after {
     counter-increment: tab-counter;
     content: counter(
       tab-counter
@@ -45,10 +42,7 @@ tabs {
   }
 
   /*  Hide tab numbers on the right side when hovering over */
-  .zen-workspace-tabs-section
-    tab:not([zen-glance-tab="true"])
-    > .tab-stack
-    > .tab-content:hover::after {
+  tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content:hover::after {
     opacity: 0; /* Make it invisible */
     width: 0; /* In order to bring the close button to the right */
     margin: 0;
@@ -65,10 +59,7 @@ tabs {
     tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::after {
       display: none; /* Hide the ::after pseudo-element first */
     }
-    .zen-workspace-tabs-section[active="true"]
-      tab:not([zen-glance-tab="true"])
-      > .tab-stack
-      > .tab-content::before {
+    tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
       counter-increment: tab-counter;
       content: counter(
         tab-counter
@@ -96,10 +87,7 @@ tabs {
   }
 } /* Styles when the sidebar is NOT expanded (compact mode) */
 @media not (-moz-bool-pref: "zen.view.sidebar-expanded") {
-  .zen-workspace-tabs-section[active="true"]
-    tab:not([zen-glance-tab="true"])
-    > .tab-stack
-    > .tab-content::before {
+  tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
     counter-increment: tab-counter;
     content: counter(tab-counter) "";
     position: absolute;
@@ -112,10 +100,7 @@ tabs {
     color: var(--number_color, inherit); /* Fallback to default color */
   } /* Put tab numbers on the left side when compact_side="Left" (AND in compact mode) */
   :root:has(#theme-Tab-Numbers[uc-theme-compact_side="Left"]) {
-    .zen-workspace-tabs-section[active="true"]
-      tab:not([zen-glance-tab="true"])
-      > .tab-stack
-      > .tab-content::before {
+    tab:not([zen-glance-tab="true"]) > .tab-stack > .tab-content::before {
       counter-increment: tab-counter;
       content: counter(tab-counter) "";
       position: absolute;

--- a/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/readme.md
+++ b/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/readme.md
@@ -2,9 +2,13 @@
 
 Shows the Number corresponding to each Tab. This can help you navigate between Tabs faster by pressing Cmd + Number of the Tab. (or Ctrl + Number on Windows)
 
-Additions (v1.0.6 - current version):
+Additions (v1.0.7 - current version):
 
-Fixed tab numbering across workspaces.
+- Reverted back to a previous version.
+
+Additions (v1.0.6):
+
+- Fixed tab numbering across workspaces.
 
 Additions (v1.0.5):
 

--- a/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/theme.json
+++ b/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/theme.json
@@ -1,17 +1,15 @@
 {
-    "id": "22c9ec3b-7c62-46ae-991f-c8fff5046829",
-    "name": "Tab Numbers",
-    "description": "Shows the Number corresponding to each Tab.",
-    "homepage": "https://github.com/philmard/tab-numbers",
-    "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/chrome.css",
-    "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/readme.md",
-    "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/image.png",
-    "author": "philmard",
-    "version": "1.0.6",
-    "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/preferences.json",
-    "tags": [
-        "tabs"
-    ],
-    "createdAt": "2024-11-09",
-    "updatedAt": "2025-05-14"
+  "id": "22c9ec3b-7c62-46ae-991f-c8fff5046829",
+  "name": "Tab Numbers",
+  "description": "Shows the Number corresponding to each Tab.",
+  "homepage": "https://github.com/philmard/tab-numbers",
+  "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/chrome.css",
+  "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/readme.md",
+  "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/image.png",
+  "author": "philmard",
+  "version": "1.0.7",
+  "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/22c9ec3b-7c62-46ae-991f-c8fff5046829/preferences.json",
+  "tags": ["tabs"],
+  "createdAt": "2024-11-09",
+  "updatedAt": "2025-05-14"
 }


### PR DESCRIPTION
Reverted back to previous version, because it broke in version v1.12.6b of Zen Browser.