### PR TITLE
Update SuperPins.

### DIFF
--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
@@ -74,6 +74,19 @@
         }
     }
 
+    :root:has(#theme-SuperPins[uc-tabs-show-separator="never"]) {
+        .vertical-pinned-tabs-container-separator {
+            display: none !important;
+        }
+
+        #vertical-pinned-tabs-container>.zen-workspace-tabs-section,
+        .zen-workspace-pinned-tabs-section {
+            &:has(> :nth-child(2)) {
+                padding-bottom: 5px !important;
+            }
+        }
+    }
+
     /* Enables legacy layout for pinned tabs (icon only in grid) */
     @media (-moz-bool-pref: "uc.pins.legacy-layout") {
         #navigator-toolbox[zen-sidebar-expanded="true"] {
@@ -195,19 +208,6 @@
             transform: translateX(-50%) !important;
             width: calc(100% - var(--zen-toolbox-padding) * 2) !important;
         }
-
-        :root:has(#theme-SuperPins[uc-tabs-show-separator="never"]) {
-            .vertical-pinned-tabs-container-separator {
-                display: none !important;
-            }
-
-            #vertical-pinned-tabs-container>.zen-workspace-tabs-section,
-            .zen-workspace-pinned-tabs-section {
-                &:has(> :nth-child(2)) {
-                    padding-bottom: 5px !important;
-                }
-            }
-        }
     }
 
     /* Make Essentials look more box like */
@@ -254,23 +254,6 @@
 
     /* Puts Essentials at the bottom */
     :root:has(#theme-SuperPins[uc-essentials-position="bottom"]) {
-        .tabbrowser-tab:not([pinned]), #tabs-newtab-button {
-            margin-left: var(--zen-toolbox-padding) !important;
-            margin-right: var(--zen-toolbox-padding) !important;
-        }
-
-        .zen-workspace-pinned-tabs-section {
-            max-width: calc(100% - var(--zen-toolbox-padding) * 3) !important;
-            min-width: calc(100% - var(--zen-toolbox-padding) * 3) !important;
-            width: calc(100% - var(--zen-toolbox-padding) * 3) !important;
-            padding-left: calc(var(--zen-toolbox-padding) * 2) !important;
-        }
-
-        .vertical-pinned-tabs-container-separator {
-            width: calc(100% - var(--zen-toolbox-padding) * 3) !important;
-            margin-left: calc(var(--zen-toolbox-padding) / 2) !important;
-        }
-
         #tabbrowser-arrowscrollbox {
             position: relative !important;
             overflow-x: hidden !important;
@@ -287,6 +270,7 @@
         }
 
         #tabbrowser-arrowscrollbox > zen-workspace {
+            width: 100% !important;
             padding-top: 0 !important;
         }
 
@@ -584,6 +568,12 @@
     }
 
     @media (-moz-bool-pref: "uc.pins.stay-at-top") {
+        @media (-moz-bool-pref: "theme.nosidebarscrollbar.before125b") {
+            #tabbrowser-arrowscrollbox .zen-workspace-normal-tabs-section {
+                scrollbar-width: none !important;
+            }
+        }
+        
         zen-workspace > arrowscrollbox.workspace-arrowscrollbox {
             overflow-y: hidden !important;
             flex-basis: 100%;


### PR DESCRIPTION
This version fixes the "Keep pinned tabs at the top" setting not working with the no-sidebar-mod and it allows the never show separator option to work when the legacy layout of pins is not enabled.