### PR TITLE
Updated theme a6335949-4465-4b71-926c-4a52d34bc9c0 (better-findbar)

### DIFF
--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/chrome.css
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/chrome.css
@@ -7,9 +7,6 @@
 	--better-findbar-position-left: 50%;
 	--better-findbar-position-right: auto;
 }
-.browserContainer {
-	overflow: clip
-}
 
 findbar {
 	display: flex !important;
@@ -32,7 +29,7 @@ findbar {
 	overflow: unset !important;
 	box-shadow: var(--box-shadow-10);
 
-	background: var(--zen-colors-tertiary) !important;
+	background: var(--toolbar-bgcolor) !important;
 	border: 1px solid var(--zen-colors-border) !important;
 
 	transition: transform 0.35s ease !important;

--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/theme.json
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/theme.json
@@ -8,7 +8,7 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/image.png",
     "author": "RobotoSkunk",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/preferences.json",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "tags": [
         "find",
         "bar",
@@ -17,5 +17,5 @@
         "find-bar"
     ],
     "createdAt": "2024-11-24",
-    "updatedAt": "2025-05-22"
+    "updatedAt": "2025-07-18"
 }


### PR DESCRIPTION
Changelog:
- Fixed incompatibility with light/dark modes.
- Removed content clipping to prevent [future issues with Glance](https://github.com/zen-browser/desktop/commit/5ad1c6c3230a48590a4e5b227ff0ce08fe83cd82).
