### PR TITLE
Fix SuperPins on Twilight.

### DIFF
--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css
@@ -75,7 +75,7 @@
     }
 
     :root:has(#theme-SuperPins[uc-tabs-show-separator="never"]) {
-        .vertical-pinned-tabs-container-separator {
+        .vertical-pinned-tabs-container-separator, .pinned-tabs-container-separator {
             display: none !important;
         }
 
@@ -201,12 +201,18 @@
             }
         }
 
-        .vertical-pinned-tabs-container-separator {
+        .vertical-pinned-tabs-container-separator, .pinned-tabs-container-separator {
             position: absolute !important;
             bottom: 7px !important;
             left: 50% !important;
             transform: translateX(-50%) !important;
             width: calc(100% - var(--zen-toolbox-padding) * 2) !important;
+        }
+
+        @media (-moz-bool-pref: "arcline.superpin") {
+            .vertical-pinned-tabs-container-separator, .pinned-tabs-container-separator {
+                bottom: -4px !important;
+            }
         }
     }
 
@@ -265,6 +271,11 @@
             padding-top: 8px !important;
         }
 
+        /* Adds padding-bottom only when media controls are visible */
+        #zen-media-controls-toolbar:not([hidden]) ~ .zen-essentials-container {
+            padding-bottom: 10px !important;
+        }
+        
         #zen-essentials-container, #zen-essentials {
             order: 999 !important;
         }
@@ -519,8 +530,10 @@
             }
 
             #zen-essentials-container, .zen-essentials-container {
-                &:has(> :nth-child(1))~#zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section .vertical-pinned-tabs-container-separator {
-                    max-height: unset !important;
+                &:has(> :nth-child(1))~#zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
+                    .vertical-pinned-tabs-container-separator, .pinned-tabs-container-separator {
+                        max-height: unset !important;
+                    }
                 }
             }
         }

--- a/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
+++ b/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/theme.json
@@ -7,7 +7,7 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/image.png",
     "author": "CosmoCreeper",
-    "version": "1.5.6",
+    "version": "1.5.7",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json",
     "tags": [
         "tabs"


### PR DESCRIPTION
This new update to SuperPins fixes the separator appearing on the same grid as pinned tabs.