### PR TITLE
Update Theme: `bleeding-corners-fix` to `1.0.6`

### DIFF
--- a/themes/7d577b21-4685-4db2-bb17-d39d08eec199/chrome.css
+++ b/themes/7d577b21-4685-4db2-bb17-d39d08eec199/chrome.css
@@ -1,4 +1,5 @@
-html:not([sizemode="fullscreen"]) .browserContainer,
-html:not([sizemode="fullscreen"]) .browserStack {
-	clip-path: inset(0 round var(--zen-native-inner-radius));
+html:not([sizemode="fullscreen"]) {
+	.browserStack, browser {
+		clip-path: inset(0 round var(--zen-native-inner-radius));
+	}
 }

--- a/themes/7d577b21-4685-4db2-bb17-d39d08eec199/readme.md
+++ b/themes/7d577b21-4685-4db2-bb17-d39d08eec199/readme.md
@@ -7,14 +7,18 @@ On some websites, the HTML background color can sometimes bleed-through the edge
 
 ## Change log
 
+### 1.0.6
+- 🐛 Fixed clip-path being applied 1 layer too high (see issue #10).
+- 📝 Update description to mention possible increase in GPU usage.
+
 ### 1.0.5
-- 🩹 Fixed rounded corners from appearing in fullscreen (see #3).
+- 🩹 Fixed rounded corners from appearing in fullscreen (see pull request #3).
 
 ### 1.0.4
-- 🔧 Changed homepage URL path to point to the mod directory itself, instead of the root repository (see #2).
+- 🔧 Changed homepage URL path to point to the mod directory itself, instead of the root repository (see pull request #2).
 
 ### 1.0.3
-- 🐛 Fixed clip-path not applying to websites using the `backdrop-filter` effect (see #1).
+- 🐛 Fixed clip-path not applying to websites using the `backdrop-filter` effect (see pull request #1).
 
 ### 1.0.2
 - 📝 Updated README.

--- a/themes/7d577b21-4685-4db2-bb17-d39d08eec199/theme.json
+++ b/themes/7d577b21-4685-4db2-bb17-d39d08eec199/theme.json
@@ -1,14 +1,14 @@
 {
     "id": "7d577b21-4685-4db2-bb17-d39d08eec199",
     "name": "Bleeding Corners Fix",
-    "description": "(May cause high GPU usage!) Fixes the white outlines (or artifacts) on the rounded corners that can appear on some pages.",
+    "description": "Fixes the white outlines (or artifacts) on the rounded corners that can appear on some pages. May cause higher GPU usage on some devices.",
     "homepage": "https://github.com/rsiebertdev/zen-themes/tree/main/bleeding-corners-fix",
     "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/7d577b21-4685-4db2-bb17-d39d08eec199/chrome.css",
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/7d577b21-4685-4db2-bb17-d39d08eec199/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/7d577b21-4685-4db2-bb17-d39d08eec199/image.png",
     "author": "rsiebertdev",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "tags": [],
     "createdAt": "2025-02-17",
-    "updatedAt": "2025-07-22"
+    "updatedAt": "2025-07-27"
 }


### PR DESCRIPTION
Please see changelog for details. This mod is maintained over at https://github.com/rsiebertdev/zen-themes.