### PR TITLE
Update Theme better-findbar (bugs fix)

### DIFF
--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/chrome.css
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/chrome.css
@@ -29,8 +29,8 @@ findbar {
 	overflow: unset !important;
 	box-shadow: var(--box-shadow-10);
 
-	background: var(--toolbar-bgcolor) !important;
-	border: 1px solid var(--zen-main-browser-background-toolbar) !important;
+	background: var(--zen-colors-primary) !important;
+	border: 1px solid var(--zen-colors-border) !important;
 
 	transition: transform 0.35s ease !important;
 
@@ -91,14 +91,11 @@ body:has(
 
 /* Background blur */
 @media (-moz-bool-pref: "theme.better_find_bar.transparent_background") {
-	findbar, findbar .findbar-textbox:not([status="notfound"]) {
+	findbar,
+	findbar .findbar-textbox:not([status="notfound"]) {
 		backdrop-filter: blur(8px);
 
-		background: color-mix(in hsl, var(--zen-main-browser-background-toolbar), transparent 30%) !important;
-	}
-
-	findbar .findbar-textbox:not([status="notfound"]) {
-		background: color-mix(in hsl, var(--zen-main-browser-background-toolbar), transparent 10%) !important;
+		background: color-mix(in hsl, var(--zen-colors-primary), transparent 10%) !important;
 	}
 }
 

--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/preferences.json
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/preferences.json
@@ -1,7 +1,7 @@
 [
     {
         "property": "theme.better_find_bar.transparent_background",
-        "label": "Transparent background",
+		"label": "Transparent background (disable it if the background blur doesn't work)",
         "type": "checkbox",
         "defaultValue": true
     },

--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/theme.json
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/theme.json
@@ -8,7 +8,7 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/image.png",
     "author": "RobotoSkunk",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/preferences.json",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "tags": [
         "find",
         "bar",
@@ -17,5 +17,5 @@
         "find-bar"
     ],
     "createdAt": "2024-11-24",
-    "updatedAt": "2025-08-10"
+    "updatedAt": "2025-08-12"
 }


### PR DESCRIPTION
Changelog:
- Fixed find bar border colors.
- Replaced `--toolbar-bgcolor` and `--zen-main-browser-background-toolbar` with `--zen-colors-primary` to fix a background transparency color and have good compatibility with the browser's colors.
- Changed background transparency from 30% to 10% for users that have this backdrop-filter bug.
- Added a small notice for the transparent background option.