### PR TITLE
Update theme: better-findbar

### DIFF
--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/chrome.css
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/chrome.css
@@ -29,8 +29,8 @@ findbar {
 	overflow: unset !important;
 	box-shadow: var(--box-shadow-10);
 
-	background: var(--zen-colors-primary) !important;
-	border: 1px solid var(--zen-colors-border) !important;
+	background: var(--zen-primary-color) !important;
+	border: 1px solid var(--input-border-color) !important;
 
 	transition: transform 0.35s ease !important;
 
@@ -95,7 +95,7 @@ body:has(
 	findbar .findbar-textbox:not([status="notfound"]) {
 		backdrop-filter: blur(8px);
 
-		background: color-mix(in hsl, var(--zen-colors-primary), transparent 10%) !important;
+		background: color-mix(in hsl, var(--zen-primary-color), transparent 10%) !important;
 	}
 }
 

--- a/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/theme.json
+++ b/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/theme.json
@@ -8,13 +8,14 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/image.png",
     "author": "RobotoSkunk",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/a6335949-4465-4b71-926c-4a52d34bc9c0/preferences.json",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "tags": [
         "find",
         "bar",
         "search",
         "searchbar",
-        "find-bar"
+        "find-bar",
+		"search-bar"
     ],
     "createdAt": "2024-11-24",
     "updatedAt": "2025-08-19"


### PR DESCRIPTION
Changelog:
- Updated to v1.3.4
- Added "search-bar" tag
- Replaced `--zen-colors-primary` with `--zen-primary-color` to fix a compatibility issue after Zen 1.5
- Replaced `--zen-colors-border` with `--input-border-color` just to make the find bar look better