### PR TITLE
Hotfix for sidebar background revert by zen

### DIFF
--- a/themes/642854b5-88b4-4c40-b256-e035532109df/chrome.css
+++ b/themes/642854b5-88b4-4c40-b256-e035532109df/chrome.css
@@ -183,7 +183,7 @@ tabpanels .browserStack browser {
     width: var(--zen-sidebar-custom-width) !important;
   }
 
-  #zen-toolbar-background, #zen-toolbar-background::after{
+  #zen-toolbar-background, #zen-toolbar-background::after, .zen-toolbar-background, .zen-toolbar-background::after{
   background-color: color-mix(in srgb, var(--arrowpanel-background) 30%, transparent) !important;
 }
 }


### PR DESCRIPTION
## Changes
- Fixed transparent compact sidebar workarounds again.

---

This pull request makes a minor improvement to the toolbar background styling in the `chrome.css` theme file. The change ensures that both the `#zen-toolbar-background` and `.zen-toolbar-background` elements, along with their `::after` pseudo-elements, have consistent background coloring.

* Updated the CSS selector to include `.zen-toolbar-background` and `.zen-toolbar-background::after` for consistent background color styling across both ID and class-based toolbar backgrounds.