### PR TITLE
[update-theme]: Back Fwd Always Hidden

### DIFF
--- a/themes/4a222d82-2803-4ed2-a390-90abfce4f195/chrome.css
+++ b/themes/4a222d82-2803-4ed2-a390-90abfce4f195/chrome.css
@@ -1,7 +1,9 @@
-
+:root:not([customizing]) #zen-sidebar-top-buttons-separator {
+  display: none !important;
+}
 :root:not([customizing]) #back-button {
-    display: none !important;
-  }
-  :root:not([customizing]) #forward-button {
-    display: none !important;
-  }
+  display: none !important;
+}
+:root:not([customizing]) #forward-button {
+  display: none !important;
+}

--- a/themes/4a222d82-2803-4ed2-a390-90abfce4f195/theme.json
+++ b/themes/4a222d82-2803-4ed2-a390-90abfce4f195/theme.json
@@ -7,8 +7,8 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4a222d82-2803-4ed2-a390-90abfce4f195/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/4a222d82-2803-4ed2-a390-90abfce4f195/image.png",
     "author": "jean06560",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "tags": [],
     "createdAt": "2025-03-06",
-    "updatedAt": "2025-03-07"
+    "updatedAt": "2025-11-23"
 }


### PR DESCRIPTION
Hide the sidebar separator for a cleaner interface and update the version number to reflect recent changes.

<img width="192" height="54" alt="image" src="https://github.com/user-attachments/assets/09540824-bb9a-4c04-83e7-6c4c53c1c818" />


REF: https://github.com/zen-browser/desktop/discussions/11403#discussioncomment-15053642