### PR TITLE
[update-theme] Remove Tab X 1.1.1

### DIFF
--- a/themes/1b88a6d1-d931-45e8-b6c3-bfdca2c7e9d6/theme.json
+++ b/themes/1b88a6d1-d931-45e8-b6c3-bfdca2c7e9d6/theme.json
@@ -7,8 +7,9 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/1b88a6d1-d931-45e8-b6c3-bfdca2c7e9d6/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/1b88a6d1-d931-45e8-b6c3-bfdca2c7e9d6/image.png",
     "author": "xXMacMillanXx",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "tags": [],
     "createdAt": "2025-03-11",
-    "updatedAt": "2026-02-14"
+    "updatedAt": "2026-02-15",
+    "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/1b88a6d1-d931-45e8-b6c3-bfdca2c7e9d6/preferences.json"
 }


### PR DESCRIPTION
Update Remove Tab X mod #1255 

Changes:
- fix: add preferences to theme.json, to make the mod usable again
- version: 1.1.0 -> 1.1.1