### PR TITLE
Update Ghost Tabs to v1.1.0

### DIFF
--- a/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/chrome.css
+++ b/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/chrome.css
@@ -1,10 +1,15 @@
-
 /* Ghost Tabs - Zen Browser Mod */
 /* Makes unloaded/inactive tabs appear ghost-like */
 
 :root {
-    --ghost-filter: grayscale(1);
-    --ghost-opacity: 0.5;
+    --ghost-filter: none;
+    --ghost-opacity: calc(var(--mod-ghost_tabs-opacity, 50) * 0.01);
+}
+
+@media (-moz-bool-pref: "mod.ghost_tabs.bw_enabled") {
+    :root {
+        --ghost-filter: saturate(calc(var(--mod-ghost_tabs-saturation, 0) * 1%));
+    }
 }
 
 /* Pending tabs appear ghost-like */

--- a/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/preferences.json
+++ b/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/preferences.json
@@ -1,0 +1,22 @@
+[
+    {
+        "property": "mod.ghost_tabs.saturation",
+        "label": "Saturation (0-100)",
+        "type": "string",
+        "defaultValue": "0",
+        "placeholder": "e.g. 50"
+    },
+    {
+        "property": "mod.ghost_tabs.opacity",
+        "label": "Opacity (0-100)",
+        "type": "string",
+        "defaultValue": "50",
+        "placeholder": "e.g. 30"
+    },
+    {
+        "property": "mod.ghost_tabs.bw_enabled",
+        "label": "Enable Black & White effect",
+        "type": "checkbox",
+        "defaultValue": true
+    }
+]

--- a/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/theme.json
+++ b/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/theme.json
@@ -7,8 +7,8 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/image.png",
     "author": "Seismix",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "tags": [],
     "createdAt": "2025-10-02",
-    "updatedAt": "2025-10-02"
+    "updatedAt": "2026-03-10"
 }


### PR DESCRIPTION
- Add user-configurable opacity, saturation, and black & white toggle via new `preferences.json`
- Replace hardcoded `grayscale(1)` / `0.5` opacity with preference-driven values
- Bump version from 1.0.0 to 1.1.0