### PR TITLE
Fix ghost-tabs

### DIFF
--- a/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/chrome.css
+++ b/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/chrome.css
@@ -6,7 +6,7 @@
     --ghost-opacity: calc(var(--mod-ghost_tabs-opacity, 50) * 0.01);
 }
 
-@media (-moz-bool-pref: "mod.ghost_tabs.bw_enabled") {
+@media (-moz-pref("mod.ghost_tabs.bw_enabled")) {
     :root {
         --ghost-filter: saturate(calc(var(--mod-ghost_tabs-saturation, 0) * 1%));
     }

--- a/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/theme.json
+++ b/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/theme.json
@@ -7,8 +7,9 @@
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/image.png",
     "author": "Seismix",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "tags": [],
+    "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/c01d3e22-1cee-45c1-a25e-53c0f180eea8/preferences.json",
     "createdAt": "2025-10-02",
-    "updatedAt": "2026-03-11"
+    "updatedAt": "2026-03-12"
 }


### PR DESCRIPTION
Follow-up to #1931 which added `preferences.json` but missed the preferences URL in `theme.json`. At the time, I thought I couldn't reference the file since it didn't exist on main yet. Though in hindsight, the raw GitHub URL is deterministic, so I could have included it in the same PR knowing it would resolve once merged.

### Description

- add the missing preferences URL to `theme.json`
- fix the deprecated -moz-bool-pref media query syntax to `-moz-pref()` per https://docs.zen-browser.app/themes-store/themes-marketplace-preferences.

Sorry for the hassle!