### PR TITLE
Update Theme: trackpad animation

### DIFF
--- a/themes/8039de3b-72e1-41ea-83b3-5077cf0f98d1/chrome.css
+++ b/themes/8039de3b-72e1-41ea-83b3-5077cf0f98d1/chrome.css
@@ -3,7 +3,15 @@
   --mod-browser-ease-swipe: var(--user-browser-ease-swipe, 0.3, 1.2, 0.5, 1);
   --mod-browser-ease-reset: var(--user-browser-ease-reset, 0.2, 1.4, 0.3, 1);
   --mod-browser-radius-default: var(--user-tab-radius, 8px);
-  --mod-browser-translate-x: var(--user-tab-movement, 2%); 
+  --mod-browser-translate-x: var(--user-tab-movement, 2%);
+}
+
+/* In fullscreen (e.g. fullscreen video) square off the corners so the page
+   background does not bleed through the rounded corners. Zeroing the radius
+   variable collapses both the default (x1) and swipe (x2) radii to 0. */
+:root[sizemode="fullscreen"],
+:root[inDOMFullscreen="true"] {
+  --mod-browser-radius-default: 0px;
 }
 
 @media (-moz-bool-pref: "tab-shadow-enabled") {

--- a/themes/8039de3b-72e1-41ea-83b3-5077cf0f98d1/theme.json
+++ b/themes/8039de3b-72e1-41ea-83b3-5077cf0f98d1/theme.json
@@ -8,8 +8,8 @@
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/8039de3b-72e1-41ea-83b3-5077cf0f98d1/image.png",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/8039de3b-72e1-41ea-83b3-5077cf0f98d1/preferences.json",
     "author": "Fury7425",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "tags": [],
     "createdAt": "2025-04-08",
-    "updatedAt": "2025-05-21"
+    "updatedAt": "2026-06-11"
 }


### PR DESCRIPTION
## What

Square off the page corners when the browser is in fullscreen so the page
background no longer bleeds through the rounded corners (most visible on
fullscreen video).

## Why

`.browserStack browser` was given `border-radius: var(--mod-browser-radius-default)`
in every state, including fullscreen. In fullscreen there's no chrome behind the
page, so the rounded corners exposed the window background as a colored
outline/artifact at each corner.

## How

Override the radius variable to `0` while fullscreen instead of touching the
rule selectors directly:

```css
:root[sizemode="fullscreen"],
:root[inDOMFullscreen="true"] {
  --mod-browser-radius-default: 0px;
}