### PR TITLE
fix: restrict hover trigger to 4px strip and fix bookmark overflow

### DIFF
--- a/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/chrome.css
+++ b/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/chrome.css
@@ -129,6 +129,13 @@ menuitem.bookmark-item[label*="github"] .menu-icon {
     height: unset !important;
     min-height: unset !important;
     margin-bottom: 0px !important;
+    width: 100% !important;
+  }
+
+  /* Constrain width so overflow chevron appears correctly */
+  #zen-appcontent-navbar-container:hover #PlacesToolbarItems {
+    max-width: 100% !important;
+    overflow: hidden !important;
   }
 }
 

--- a/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/chrome.css
+++ b/themes/ea1a5ace-f698-4b45-ab88-6e8bd3a563f0/chrome.css
@@ -102,6 +102,10 @@ menuitem.bookmark-item[label*="github"] .menu-icon {
 
   /* Only apply hiding when bookmarks toolbar is actually enabled */
   #PersonalToolbar:not([collapsed]):not([customizing]) {
+    height: 4px !important;
+    min-height: 4px !important;
+    margin-bottom: -4px !important;
+    overflow: visible !important;
     position: relative;
     margin-bottom: calc(0px - var(--urlbar-min-height));
     transform: rotateX(90deg) !important;
@@ -120,6 +124,11 @@ menuitem.bookmark-item[label*="github"] .menu-icon {
 @media (-moz-bool-pref: "uc.bookmarks.expand-on-hover") {
   #zen-appcontent-navbar-container:hover #PersonalToolbar:not([collapsed]) {
     transform: rotateX(0deg) !important;
+    /* position: absolute to float over webpage without pushing layout */
+    position: absolute !important;
+    height: unset !important;
+    min-height: unset !important;
+    margin-bottom: 0px !important;
   }
 }
 


### PR DESCRIPTION
Fixes #2041

Fixes two issues with the bookmarks toolbar:

* The hover area covered the entire 70px navbar, making it trigger too easily. It's now limited to a 4px strip by giving the toolbar an explicit height and using `margin-bottom: -4px` so it doesn't affect page layout. When expanded, the toolbar switches to `position: absolute` so it overlays the page instead of causing a reflow.

* The bookmarks toolbar wasn't showing the `>` chevron when there were too many bookmarks because the items could overflow. Fixed by setting the toolbar to `width: 100%` and adding `overflow: hidden` to `#PlacesToolbarItems`.
